### PR TITLE
Integrate PDF parser and LanceDB

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Dependencies
       run: sudo apt install protobuf-compiler
+    - name: Setup
+      run: cp .env.tmpl .env
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
     - name: Dependencies
       run: sudo apt install protobuf-compiler
+    - uses: actions/checkout@v4
     - name: Setup
       run: cp .env.tmpl .env
-    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ftail"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdfb03d554599f140807fcf79f0363cfa7024a328e3030da47145b4350a130b0"
+dependencies = [
+ "chrono",
+ "log",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lopdf"
@@ -5491,7 +5501,10 @@ dependencies = [
  "arrow-schema",
  "directories",
  "dotenv",
+ "ftail",
  "libsqlite3-sys",
+ "log",
+ "pdftools",
  "rag",
  "reqwest",
  "rusqlite",

--- a/pdftools/src/parse.rs
+++ b/pdftools/src/parse.rs
@@ -9,7 +9,7 @@ use lopdf::Document;
 use crate::math::{from_cmex, from_cmmi, from_cmsy, from_msbm};
 
 const ASCII_PLUS: u8 = b'+';
-const DEFAULT_SAME_WORD_THRESHOLD: i32 = 60;
+const DEFAULT_SAME_WORD_THRESHOLD: f32 = 60.0;
 const DEFAULT_SUBSCRIPT_THRESHOLD: f32 = 9.0;
 
 /// A wrapper for all PDF parsing errors
@@ -41,7 +41,7 @@ impl std::fmt::Display for PdfError {
 #[derive(Debug)]
 struct PdfParserConfig {
     /// Threshold for determining when to join words
-    same_word_threshold: i32,
+    same_word_threshold: f32,
     /// Vertical movement threshold to declare sub/superscript
     subscript_threshold: f32,
 }
@@ -234,6 +234,9 @@ impl PdfParser {
                 let idx1 = cur_content.find('(').ok_or(PdfError::ContentError)?;
                 let idx2 = cur_content.find(')').ok_or(PdfError::ContentError)?;
 
+                // TODO: If ) is preceded by a \, then it may be escaped, and we may have to have
+                // logic to account for this.
+
                 if idx1 >= idx2 {
                     break;
                 }
@@ -250,9 +253,9 @@ impl PdfParser {
                 }
 
                 let idx3 = cur_content[idx2..].find('(').unwrap() + idx2;
-                let spacing = cur_content[idx2 + 1..idx3].parse::<i32>().unwrap().abs();
+                let spacing = cur_content[idx2 + 1..idx3].parse::<f32>().unwrap().abs();
 
-                if !(0..=self.config.same_word_threshold).contains(&spacing) {
+                if !(0.0..=self.config.same_word_threshold).contains(&spacing) {
                     parsed += " ";
                 }
 

--- a/zqa/Cargo.toml
+++ b/zqa/Cargo.toml
@@ -11,10 +11,13 @@ libsqlite3-sys = "^0.32"
 rusqlite = "0.34.0"
 dotenv = "0.15.0"
 rag = { path = "../rag/"}
+pdftools = { path = "../pdftools/"}
 reqwest = "0.12.14"
 serde = "1.0.219"
 serde_json = "1.0.140"
 tokio = "1.44.1"
+ftail = "0.2.1"
+log = "0.4.27"
 
 [[bin]]
 name = "zqa"

--- a/zqa/src/chain.rs
+++ b/zqa/src/chain.rs
@@ -1,3 +1,5 @@
+use ftail::Ftail;
+
 pub mod tasks;
 pub mod utils;
 
@@ -13,6 +15,7 @@ pub fn get_zotero_qa_chain() -> Chain<UserInput> {
 }
 
 pub fn main() {
+    Ftail::new().console(log::LevelFilter::Info).init().unwrap();
     let mut chain = get_zotero_qa_chain();
     chain.run();
 }

--- a/zqa/src/utils/library.rs
+++ b/zqa/src/utils/library.rs
@@ -5,6 +5,8 @@ use std::env;
 use std::error::Error;
 use std::path::PathBuf;
 
+use pdftools::parse::extract_text;
+
 /// Gets the Zotero library path. Works on Linux, macOS, and Windows systems.
 ///
 /// Returns None if either the OS is not one of the above, or if we could not
@@ -19,6 +21,7 @@ fn get_lib_path() -> Option<PathBuf> {
 }
 
 /// Metadata for items in the Zotero library.
+#[derive(Clone)]
 pub struct ZoteroItemMetadata {
     pub library_key: String,
     pub title: String,
@@ -27,10 +30,18 @@ pub struct ZoteroItemMetadata {
     pub file_path: PathBuf,
 }
 
+/// A Zotero library item. Includes full-text from parsing PDFs when they exist.
+/// TODO: For now, we assume the PDF text always exists. This should be generalized later.
+pub struct ZoteroItem {
+    pub metadata: ZoteroItemMetadata,
+    pub text: String,
+}
+
 /// A general error struct for Zotero library parsing.
 #[derive(Clone, Debug)]
 pub enum LibraryParsingError {
     LibNotFoundError,
+    PdfParsingError(String),
 }
 
 impl From<rusqlite::Error> for LibraryParsingError {
@@ -39,18 +50,25 @@ impl From<rusqlite::Error> for LibraryParsingError {
     }
 }
 
+impl From<Box<dyn Error>> for LibraryParsingError {
+    fn from(value: Box<dyn Error>) -> Self {
+        LibraryParsingError::PdfParsingError(value.to_string())
+    }
+}
+
 impl fmt::Display for LibraryParsingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             LibraryParsingError::LibNotFoundError => write!(f, "Library not found!"),
+            LibraryParsingError::PdfParsingError(m) => write!(f, "PDF parsing error: {}", m),
         }
     }
 }
 
 impl Error for LibraryParsingError {}
 
-/// Parses the Zotero library. If successful, returns a list of metadata for each item.
-pub fn parse_library() -> Result<Vec<ZoteroItemMetadata>, LibraryParsingError> {
+/// Parses the Zotero library metadata. If successful, returns a list of metadata for each item.
+pub fn parse_library_metadata() -> Result<Vec<ZoteroItemMetadata>, LibraryParsingError> {
     if let Some(path) = get_lib_path() {
         let conn = Connection::open(path.join("zotero.sqlite"))?;
 
@@ -76,7 +94,7 @@ pub fn parse_library() -> Result<Vec<ZoteroItemMetadata>, LibraryParsingError> {
             .query_map([], |row| {
                 let res_path: String = row.get(4)?;
                 let split_idx = res_path.find(':').unwrap_or(0);
-                let filename = res_path.split_at(split_idx).1;
+                let filename = res_path.split_at(split_idx + 1).1;
                 let lib_key: String = row.get(0)?;
 
                 Ok(ZoteroItemMetadata {
@@ -96,6 +114,55 @@ pub fn parse_library() -> Result<Vec<ZoteroItemMetadata>, LibraryParsingError> {
     }
 }
 
+/// Parses the Zotero library, also parsing PDF files if they exist on disk. If not, we currently
+/// discard those items. TODO: Update this logic later on.
+pub fn parse_library() -> Result<Vec<ZoteroItem>, LibraryParsingError> {
+    let metadata = parse_library_metadata()?;
+
+    let mut failed_count = 0;
+    let items = metadata
+        .iter()
+        .filter_map(|m| {
+            let path_str = match m.file_path.to_str() {
+                Some(p) => p,
+                None => {
+                    failed_count += 1;
+                    log::warn!(
+                        "Skipping item with invalid UTF-8 in path: {:?}",
+                        m.library_key
+                    );
+                    return None;
+                }
+            };
+
+            match extract_text(path_str) {
+                Ok(text) => Some(ZoteroItem {
+                    metadata: m.clone(),
+                    text,
+                }),
+                Err(e) => {
+                    failed_count += 1;
+                    log::warn!(
+                        "Failed to parse PDF for item {} with path {}: {}",
+                        m.library_key,
+                        path_str,
+                        e
+                    );
+                    None
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if failed_count > 0 {
+        log::warn!("Failed to parse {} PDF files", failed_count);
+    }
+
+    log::info!("Parsed {} items from library.", items.len());
+
+    Ok(items)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -107,7 +174,7 @@ mod tests {
             return;
         }
 
-        let library_items = parse_library();
+        let library_items = parse_library_metadata();
 
         assert!(library_items.is_ok());
         let items = library_items.unwrap();


### PR DESCRIPTION
This PR is the first step in integrating the `pdftools` and `rag` crates with the `zqa` binary. A bug in `pdftools` is marked as a todo; that should be addressed separately.
