### PR TITLE
Handle empty strings correctly for voyage ai embeddings

### DIFF
--- a/rag/src/llm/voyage.rs
+++ b/rag/src/llm/voyage.rs
@@ -85,9 +85,10 @@ where
 
             // 3. If none are real, just push zeros for whole batch
             if cur_texts.is_empty() {
-                all_embeddings.extend(
-                    std::iter::repeat_n(vec![0.0; VOYAGE_EMBEDDING_DIM as usize], batch.len()),
-                );
+                all_embeddings.extend(std::iter::repeat_n(
+                    vec![0.0; VOYAGE_EMBEDDING_DIM as usize],
+                    batch.len(),
+                ));
             } else {
                 let request = VoyageAIRequest::from_texts(cur_texts);
 
@@ -164,7 +165,8 @@ where
         }
 
         let n_embeddings = all_embeddings.len();
-        let emb_shape = all_embeddings.first()
+        let emb_shape = all_embeddings
+            .first()
             .ok_or(LLMError::GenericLLMError(String::from(
                 "Could not compute embedding shape--this should not happen.",
             )))?


### PR DESCRIPTION
This PR fixes a bug where empty strings inside batches of text were not correctly handled, so that the number of embeddings was less than the number of texts. This PR correctly adds zero vectors as needed, and not just when the entire batch has empty strings.