### PR TITLE
refactor(rag)!: add registry system for providers

### DIFF
--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -461,7 +461,7 @@ impl PdfParser {
                                             .collect::<Result<_, _>>()
                                             .map_err(|_| PdfError::InvalidUtf8)?;
 
-                                        let unicode: String = decode_utf16(code_units.into_iter())
+                                        let unicode: String = decode_utf16(code_units)
                                             .map(|r| {
                                                 r.map_err(|e| {
                                                     PdfError::EncodingError(format!(

--- a/zqa-rag/src/capabilities.rs
+++ b/zqa-rag/src/capabilities.rs
@@ -2,11 +2,18 @@
 //! providers exposed through this crate have which capabilities. Note that it is possible for a
 //! provider to not have all the capabilities listed here, if that API endpoint is not (yet) supported.
 
+use lancedb::embeddings::EmbeddingFunction;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
+use std::{cmp::Ordering, sync::Arc};
 use zqa_pdftools::chunk::ChunkingStrategy;
 
-use crate::llm::errors::LLMError;
+use crate::{
+    config::LLMClientConfig,
+    embedding::common::EmbeddingProviderConfig,
+    llm::{errors::LLMError, factory::LLMClient},
+    providers::provider_id::ProviderId,
+    reranking::common::{Rerank, RerankProviderConfig},
+};
 
 /// Providers of models that can generate text. Clients for these providers should implement
 /// the `ApiClient` trait. Generally speaking, for this reason, these structs and all their trait
@@ -271,6 +278,24 @@ impl RerankerProvider {
         ]
         .contains(&provider)
     }
+}
+
+pub trait LlmFactory: Send + Sync {
+    fn provider_id(&self) -> ProviderId;
+    fn create_llm(&self, config: &LLMClientConfig) -> Result<LLMClient, LLMError>;
+}
+
+pub trait EmbeddingFactory: Send + Sync {
+    fn provider_id(&self) -> ProviderId;
+    fn create_embedding(
+        &self,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<Arc<dyn EmbeddingFunction>, LLMError>;
+}
+
+pub trait RerankFactory: Send + Sync {
+    fn provider_id(&self) -> ProviderId;
+    fn create_reranker(&self, config: &RerankProviderConfig) -> Result<Arc<dyn Rerank>, LLMError>;
 }
 
 #[cfg(test)]

--- a/zqa-rag/src/capabilities.rs
+++ b/zqa-rag/src/capabilities.rs
@@ -37,13 +37,7 @@ impl ModelProvider {
     /// Returns the string representation of the provider.
     #[must_use]
     pub fn as_str(&self) -> &'static str {
-        match self {
-            ModelProvider::Anthropic => "anthropic",
-            ModelProvider::Ollama => "ollama",
-            ModelProvider::OpenAI => "openai",
-            ModelProvider::OpenRouter => "openrouter",
-            ModelProvider::Gemini => "gemini",
-        }
+        ProviderId::from(self).as_str()
     }
 
     /// Returns whether the provider is contained in the list of providers.
@@ -84,14 +78,7 @@ impl EmbeddingProvider {
     /// Returns the string representation of the provider.
     #[must_use]
     pub fn as_str(&self) -> &'static str {
-        match self {
-            EmbeddingProvider::Cohere => "cohere",
-            EmbeddingProvider::OpenAI => "openai",
-            EmbeddingProvider::Ollama => "ollama",
-            EmbeddingProvider::VoyageAI => "voyageai",
-            EmbeddingProvider::Gemini => "gemini",
-            EmbeddingProvider::ZeroEntropy => "zeroentropy",
-        }
+        ProviderId::from(self).as_str()
     }
 
     /// Returns whether the provider is contained in the list of providers.
@@ -261,11 +248,7 @@ impl RerankerProvider {
     /// Returns the string representation of the provider.
     #[must_use]
     pub fn as_str(&self) -> &'static str {
-        match self {
-            RerankerProvider::Cohere => "cohere",
-            RerankerProvider::VoyageAI => "voyageai",
-            RerankerProvider::ZeroEntropy => "zeroentropy",
-        }
+        ProviderId::from(self).as_str()
     }
 
     /// Returns whether the provider is contained in the list of providers.

--- a/zqa-rag/src/capabilities.rs
+++ b/zqa-rag/src/capabilities.rs
@@ -280,21 +280,42 @@ impl RerankerProvider {
     }
 }
 
+/// Factory trait to create an [`LLMClient`] for a provider.
 pub trait LlmFactory: Send + Sync {
+    /// Return the canonical provider ID
     fn provider_id(&self) -> ProviderId;
+    /// Attempt to create an [`LLMClient`] with the provided config.
+    ///
+    /// # Errors
+    ///
+    /// [`LLMError`] variant if creating an LLM client fails.
     fn create_llm(&self, config: &LLMClientConfig) -> Result<LLMClient, LLMError>;
 }
 
+/// Factory trait to create an [`EmbeddingFunction`] object
 pub trait EmbeddingFactory: Send + Sync {
+    /// Return the canonical provider ID
     fn provider_id(&self) -> ProviderId;
+    /// Attempt to create a [`EmbeddingProvider`] object with the provided config.
+    ///
+    /// # Errors
+    ///
+    /// [`LLMError`] variant if creating a trait object fails.
     fn create_embedding(
         &self,
         config: &EmbeddingProviderConfig,
     ) -> Result<Arc<dyn EmbeddingFunction>, LLMError>;
 }
 
+/// Factory trait to create an [`Rerank`] object
 pub trait RerankFactory: Send + Sync {
+    /// Return the canonical provider ID
     fn provider_id(&self) -> ProviderId;
+    /// Attempt to create a [`Rerank`] object with the provided config.
+    ///
+    /// # Errors
+    ///
+    /// [`LLMError`] variant if creating a reranker fails.
     fn create_reranker(&self, config: &RerankProviderConfig) -> Result<Arc<dyn Rerank>, LLMError>;
 }
 

--- a/zqa-rag/src/config.rs
+++ b/zqa-rag/src/config.rs
@@ -4,9 +4,12 @@
 //! instead of reading from environment variables or TOML files directly.
 //! This makes the rag crate more general and reusable.
 
-use crate::constants::{
-    DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_EMBEDDING_DIM, DEFAULT_OLLAMA_EMBEDDING_MODEL,
-    DEFAULT_OLLAMA_MAX_TOKENS, DEFAULT_OLLAMA_MODEL,
+use crate::{
+    constants::{
+        DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_EMBEDDING_DIM, DEFAULT_OLLAMA_EMBEDDING_MODEL,
+        DEFAULT_OLLAMA_MAX_TOKENS, DEFAULT_OLLAMA_MODEL,
+    },
+    providers::ProviderId,
 };
 
 /// Configuration for Anthropic LLM provider
@@ -136,4 +139,16 @@ pub enum LLMClientConfig {
     OpenRouter(crate::config::OpenRouterConfig),
     /// Gemini client configuration
     Gemini(crate::config::GeminiConfig),
+}
+
+impl LLMClientConfig {
+    pub const fn provider_id(&self) -> ProviderId {
+        match self {
+            Self::Anthropic(_) => ProviderId::Anthropic,
+            Self::Ollama(_) => ProviderId::Ollama,
+            Self::OpenAI(_) => ProviderId::OpenAI,
+            Self::OpenRouter(_) => ProviderId::OpenRouter,
+            Self::Gemini(_) => ProviderId::Gemini,
+        }
+    }
 }

--- a/zqa-rag/src/config.rs
+++ b/zqa-rag/src/config.rs
@@ -142,6 +142,8 @@ pub enum LLMClientConfig {
 }
 
 impl LLMClientConfig {
+    /// Return the canonical provider ID
+    #[must_use]
     pub const fn provider_id(&self) -> ProviderId {
         match self {
             Self::Anthropic(_) => ProviderId::Anthropic,

--- a/zqa-rag/src/embedding/common.rs
+++ b/zqa-rag/src/embedding/common.rs
@@ -11,18 +11,13 @@ use std::time::{Duration, Instant};
 use lancedb::embeddings::EmbeddingFunction;
 
 use crate::capabilities::EmbeddingProvider;
-use crate::clients::gemini::GeminiClient;
-use crate::clients::ollama::OllamaClient;
-use crate::clients::openai::OpenAIClient;
 use crate::constants::{
     DEFAULT_COHERE_EMBEDDING_DIM, DEFAULT_GEMINI_EMBEDDING_DIM, DEFAULT_OLLAMA_EMBEDDING_DIM,
     DEFAULT_OPENAI_EMBEDDING_DIM, DEFAULT_VOYAGE_EMBEDDING_DIM, DEFAULT_ZEROENTROPY_EMBEDDING_DIM,
 };
-use crate::embedding::cohere::CohereClient;
-use crate::embedding::voyage::VoyageAIClient;
-use crate::embedding::zeroentropy::ZeroEntropyClient;
-use crate::http_client::{HttpClient, ReqwestClient};
+use crate::http_client::HttpClient;
 use crate::llm::errors::LLMError;
+use crate::providers::{ProviderId, registry::default_provider_registry};
 
 /// A struct containing information about texts that failed to embed.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -91,26 +86,7 @@ pub fn get_embedding_dims_by_provider(embedding_provider: EmbeddingProvider) -> 
 pub fn get_embedding_provider_with_config(
     config: EmbeddingProviderConfig,
 ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
-    match config {
-        EmbeddingProviderConfig::OpenAI(cfg) => {
-            Ok(Arc::new(OpenAIClient::<ReqwestClient>::with_config(cfg)))
-        }
-        EmbeddingProviderConfig::VoyageAI(cfg) => {
-            Ok(Arc::new(VoyageAIClient::<ReqwestClient>::with_config(cfg)))
-        }
-        EmbeddingProviderConfig::Gemini(cfg) => {
-            Ok(Arc::new(GeminiClient::<ReqwestClient>::with_config(cfg)))
-        }
-        EmbeddingProviderConfig::Cohere(cfg) => {
-            Ok(Arc::new(CohereClient::<ReqwestClient>::with_config(cfg)))
-        }
-        EmbeddingProviderConfig::Ollama(cfg) => {
-            Ok(Arc::new(OllamaClient::<ReqwestClient>::with_config(cfg)))
-        }
-        EmbeddingProviderConfig::ZeroEntropy(cfg) => Ok(Arc::new(
-            ZeroEntropyClient::<ReqwestClient>::with_config(cfg),
-        )),
-    }
+    default_provider_registry().create_embedding(&config)
 }
 
 /// Configuration enum for embedding providers
@@ -131,6 +107,17 @@ pub enum EmbeddingProviderConfig {
 }
 
 impl EmbeddingProviderConfig {
+    pub const fn provider_id(&self) -> ProviderId {
+        match self {
+            Self::Ollama(_) => ProviderId::Ollama,
+            Self::OpenAI(_) => ProviderId::OpenAI,
+            Self::Gemini(_) => ProviderId::Gemini,
+            Self::VoyageAI(_) => ProviderId::VoyageAI,
+            Self::Cohere(_) => ProviderId::Cohere,
+            Self::ZeroEntropy(_) => ProviderId::ZeroEntropy,
+        }
+    }
+
     /// Returns the embedding provider enum
     #[must_use]
     pub fn provider(&self) -> EmbeddingProvider {

--- a/zqa-rag/src/embedding/common.rs
+++ b/zqa-rag/src/embedding/common.rs
@@ -123,28 +123,17 @@ impl EmbeddingProviderConfig {
 
     /// Returns the embedding provider enum
     #[must_use]
+    #[allow(clippy::missing_panics_doc)]
     pub fn provider(&self) -> EmbeddingProvider {
-        match self {
-            EmbeddingProviderConfig::OpenAI(_) => EmbeddingProvider::OpenAI,
-            EmbeddingProviderConfig::VoyageAI(_) => EmbeddingProvider::VoyageAI,
-            EmbeddingProviderConfig::Gemini(_) => EmbeddingProvider::Gemini,
-            EmbeddingProviderConfig::Ollama(_) => EmbeddingProvider::Ollama,
-            EmbeddingProviderConfig::Cohere(_) => EmbeddingProvider::Cohere,
-            EmbeddingProviderConfig::ZeroEntropy(_) => EmbeddingProvider::ZeroEntropy,
-        }
+        self.provider_id()
+            .try_into()
+            .expect("Embedding configs always map to embedding providers")
     }
 
     /// Returns the name of the embedding provider.
     #[must_use]
     pub fn provider_name(&self) -> &str {
-        match self {
-            EmbeddingProviderConfig::OpenAI(_) => "openai",
-            EmbeddingProviderConfig::VoyageAI(_) => "voyageai",
-            EmbeddingProviderConfig::Gemini(_) => "gemini",
-            EmbeddingProviderConfig::Ollama(_) => "ollama",
-            EmbeddingProviderConfig::Cohere(_) => "cohere",
-            EmbeddingProviderConfig::ZeroEntropy(_) => "zeroentropy",
-        }
+        self.provider_id().as_str()
     }
 }
 

--- a/zqa-rag/src/embedding/common.rs
+++ b/zqa-rag/src/embedding/common.rs
@@ -17,7 +17,8 @@ use crate::constants::{
 };
 use crate::http_client::HttpClient;
 use crate::llm::errors::LLMError;
-use crate::providers::{ProviderId, registry::default_provider_registry};
+use crate::providers::ProviderId;
+use crate::providers::registry::provider_registry;
 
 /// A struct containing information about texts that failed to embed.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -84,9 +85,9 @@ pub fn get_embedding_dims_by_provider(embedding_provider: EmbeddingProvider) -> 
 ///
 /// Returns an error if provider configuration is invalid or initialization fails.
 pub fn get_embedding_provider_with_config(
-    config: EmbeddingProviderConfig,
+    config: &EmbeddingProviderConfig,
 ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
-    default_provider_registry().create_embedding(&config)
+    provider_registry().create_embedding(config)
 }
 
 /// Configuration enum for embedding providers
@@ -107,6 +108,8 @@ pub enum EmbeddingProviderConfig {
 }
 
 impl EmbeddingProviderConfig {
+    /// Return the canonical provider ID.
+    #[must_use]
     pub const fn provider_id(&self) -> ProviderId {
         match self {
             Self::Ollama(_) => ProviderId::Ollama,

--- a/zqa-rag/src/lib.rs
+++ b/zqa-rag/src/lib.rs
@@ -42,5 +42,6 @@ pub mod embedding;
 pub(crate) mod http_client;
 pub mod llm;
 pub mod pricing;
+pub mod providers;
 pub mod reranking;
 pub mod vector;

--- a/zqa-rag/src/llm/factory.rs
+++ b/zqa-rag/src/llm/factory.rs
@@ -8,6 +8,7 @@ use crate::clients::openrouter::OpenRouterClient;
 use crate::config::LLMClientConfig;
 use crate::llm::base::{ApiClient, ChatRequest};
 use crate::llm::errors::LLMError;
+use crate::providers::registry::default_provider_registry;
 
 /// Enum representing different LLM client implementations
 #[derive(Debug, Clone)]
@@ -46,15 +47,5 @@ impl ApiClient for LLMClient {
 ///
 /// * `LLMError::InvalidProviderError` if the provider is not supported
 pub fn get_client_with_config(config: LLMClientConfig) -> Result<LLMClient, LLMError> {
-    match config {
-        LLMClientConfig::Anthropic(cfg) => {
-            Ok(LLMClient::Anthropic(AnthropicClient::with_config(cfg)))
-        }
-        LLMClientConfig::Ollama(cfg) => Ok(LLMClient::Ollama(OllamaClient::with_config(cfg))),
-        LLMClientConfig::OpenAI(cfg) => Ok(LLMClient::OpenAI(OpenAIClient::with_config(cfg))),
-        LLMClientConfig::OpenRouter(cfg) => {
-            Ok(LLMClient::OpenRouter(OpenRouterClient::with_config(cfg)))
-        }
-        LLMClientConfig::Gemini(cfg) => Ok(LLMClient::Gemini(GeminiClient::with_config(cfg))),
-    }
+    default_provider_registry().create_llm(&config)
 }

--- a/zqa-rag/src/llm/factory.rs
+++ b/zqa-rag/src/llm/factory.rs
@@ -8,7 +8,7 @@ use crate::clients::openrouter::OpenRouterClient;
 use crate::config::LLMClientConfig;
 use crate::llm::base::{ApiClient, ChatRequest};
 use crate::llm::errors::LLMError;
-use crate::providers::registry::default_provider_registry;
+use crate::providers::registry::provider_registry;
 
 /// Enum representing different LLM client implementations
 #[derive(Debug, Clone)]
@@ -23,6 +23,20 @@ pub enum LLMClient {
     OpenRouter(OpenRouterClient),
     /// Gemini client
     Gemini(GeminiClient),
+}
+
+impl LLMClient {
+    /// Return the configured model
+    #[must_use]
+    pub fn get_model_name(&self) -> Option<String> {
+        match self {
+            LLMClient::Anthropic(client) => client.config.as_ref().map(|c| c.model.clone()),
+            LLMClient::Ollama(client) => client.config.as_ref().map(|c| c.model.clone()),
+            LLMClient::OpenAI(client) => client.config.as_ref().map(|c| c.model.clone()),
+            LLMClient::OpenRouter(client) => client.config.as_ref().map(|c| c.model.clone()),
+            LLMClient::Gemini(client) => client.config.as_ref().map(|c| c.model.clone()),
+        }
+    }
 }
 
 // Implement ApiClient for LLMClient to delegate to the inner implementations
@@ -46,6 +60,6 @@ impl ApiClient for LLMClient {
 /// # Errors
 ///
 /// * `LLMError::InvalidProviderError` if the provider is not supported
-pub fn get_client_with_config(config: LLMClientConfig) -> Result<LLMClient, LLMError> {
-    default_provider_registry().create_llm(&config)
+pub fn get_client_with_config(config: &LLMClientConfig) -> Result<LLMClient, LLMError> {
+    provider_registry().create_llm(config)
 }

--- a/zqa-rag/src/providers/anthropic.rs
+++ b/zqa-rag/src/providers/anthropic.rs
@@ -1,3 +1,4 @@
+//! Anthropic provider implementation
 use crate::{
     capabilities::LlmFactory,
     clients::anthropic::AnthropicClient,
@@ -19,6 +20,8 @@ impl LlmFactory for AnthropicProvider {
             return Err(LLMError::InvalidProviderError("anthropic".into()));
         };
 
-        Ok(LLMClient::Anthropic(AnthropicClient::with_config(cfg.clone())))
+        Ok(LLMClient::Anthropic(AnthropicClient::with_config(
+            cfg.clone(),
+        )))
     }
 }

--- a/zqa-rag/src/providers/anthropic.rs
+++ b/zqa-rag/src/providers/anthropic.rs
@@ -1,0 +1,24 @@
+use crate::{
+    capabilities::LlmFactory,
+    clients::anthropic::AnthropicClient,
+    config::LLMClientConfig,
+    llm::{errors::LLMError, factory::LLMClient},
+    providers::provider_id::ProviderId,
+};
+
+/// Provider descriptor for Anthropic-backed LLM capabilities.
+pub struct AnthropicProvider;
+
+impl LlmFactory for AnthropicProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Anthropic
+    }
+
+    fn create_llm(&self, config: &LLMClientConfig) -> Result<LLMClient, LLMError> {
+        let LLMClientConfig::Anthropic(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("anthropic".into()));
+        };
+
+        Ok(LLMClient::Anthropic(AnthropicClient::with_config(cfg.clone())))
+    }
+}

--- a/zqa-rag/src/providers/cohere.rs
+++ b/zqa-rag/src/providers/cohere.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use lancedb::embeddings::EmbeddingFunction;
+
+use crate::{
+    capabilities::{EmbeddingFactory, RerankFactory},
+    embedding::{cohere::CohereClient, common::EmbeddingProviderConfig},
+    http_client::ReqwestClient,
+    llm::errors::LLMError,
+    providers::provider_id::ProviderId,
+    reranking::common::{Rerank, RerankProviderConfig},
+    vector::lance::{LanceEmbeddingRegistrar, LanceError},
+};
+
+/// Provider descriptor for Cohere capabilities.
+pub struct CohereProvider;
+
+impl EmbeddingFactory for CohereProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Cohere
+    }
+
+    fn create_embedding(
+        &self,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
+        let EmbeddingProviderConfig::Cohere(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("cohere".into()));
+        };
+
+        Ok(Arc::new(CohereClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl RerankFactory for CohereProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Cohere
+    }
+
+    fn create_reranker(&self, config: &RerankProviderConfig) -> Result<Arc<dyn Rerank>, LLMError> {
+        let RerankProviderConfig::Cohere(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("cohere".into()));
+        };
+
+        Ok(Arc::new(CohereClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl LanceEmbeddingRegistrar for CohereProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Cohere
+    }
+
+    fn register_with_lancedb(
+        &self,
+        db: &lancedb::Connection,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<(), LanceError> {
+        let EmbeddingProviderConfig::Cohere(cfg) = config else {
+            return Err(LanceError::ParameterError("Expected Cohere embedding config".into()));
+        };
+
+        db.embedding_registry().register(
+            ProviderId::Cohere.as_str(),
+            Arc::new(CohereClient::<ReqwestClient>::with_config(cfg.clone())),
+        )?;
+        Ok(())
+    }
+}

--- a/zqa-rag/src/providers/cohere.rs
+++ b/zqa-rag/src/providers/cohere.rs
@@ -1,3 +1,4 @@
+//! Cohere provider implementation
 use std::sync::Arc;
 
 use lancedb::embeddings::EmbeddingFunction;
@@ -61,7 +62,9 @@ impl LanceEmbeddingRegistrar for CohereProvider {
         config: &EmbeddingProviderConfig,
     ) -> Result<(), LanceError> {
         let EmbeddingProviderConfig::Cohere(cfg) = config else {
-            return Err(LanceError::ParameterError("Expected Cohere embedding config".into()));
+            return Err(LanceError::ParameterError(
+                "Expected Cohere embedding config".into(),
+            ));
         };
 
         db.embedding_registry().register(

--- a/zqa-rag/src/providers/gemini.rs
+++ b/zqa-rag/src/providers/gemini.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use lancedb::embeddings::EmbeddingFunction;
+
+use crate::{
+    capabilities::{EmbeddingFactory, LlmFactory},
+    clients::gemini::GeminiClient,
+    config::LLMClientConfig,
+    embedding::common::EmbeddingProviderConfig,
+    http_client::ReqwestClient,
+    llm::{errors::LLMError, factory::LLMClient},
+    providers::provider_id::ProviderId,
+    vector::lance::{LanceEmbeddingRegistrar, LanceError},
+};
+
+/// Provider descriptor for Gemini capabilities.
+pub struct GeminiProvider;
+
+impl LlmFactory for GeminiProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Gemini
+    }
+
+    fn create_llm(&self, config: &LLMClientConfig) -> Result<LLMClient, LLMError> {
+        let LLMClientConfig::Gemini(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("gemini".into()));
+        };
+
+        Ok(LLMClient::Gemini(GeminiClient::with_config(cfg.clone())))
+    }
+}
+
+impl EmbeddingFactory for GeminiProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Gemini
+    }
+
+    fn create_embedding(
+        &self,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
+        let EmbeddingProviderConfig::Gemini(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("gemini".into()));
+        };
+
+        Ok(Arc::new(GeminiClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl LanceEmbeddingRegistrar for GeminiProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Gemini
+    }
+
+    fn register_with_lancedb(
+        &self,
+        db: &lancedb::Connection,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<(), LanceError> {
+        let EmbeddingProviderConfig::Gemini(cfg) = config else {
+            return Err(LanceError::ParameterError("Expected Gemini embedding config".into()));
+        };
+
+        db.embedding_registry().register(
+            ProviderId::Gemini.as_str(),
+            Arc::new(GeminiClient::<ReqwestClient>::with_config(cfg.clone())),
+        )?;
+        Ok(())
+    }
+}

--- a/zqa-rag/src/providers/gemini.rs
+++ b/zqa-rag/src/providers/gemini.rs
@@ -1,3 +1,4 @@
+//! Gemini provider implementation
 use std::sync::Arc;
 
 use lancedb::embeddings::EmbeddingFunction;
@@ -60,7 +61,9 @@ impl LanceEmbeddingRegistrar for GeminiProvider {
         config: &EmbeddingProviderConfig,
     ) -> Result<(), LanceError> {
         let EmbeddingProviderConfig::Gemini(cfg) = config else {
-            return Err(LanceError::ParameterError("Expected Gemini embedding config".into()));
+            return Err(LanceError::ParameterError(
+                "Expected Gemini embedding config".into(),
+            ));
         };
 
         db.embedding_registry().register(

--- a/zqa-rag/src/providers/mod.rs
+++ b/zqa-rag/src/providers/mod.rs
@@ -1,3 +1,5 @@
+//! Provider implementations, traits, and registry
+
 pub mod anthropic;
 pub mod cohere;
 pub mod gemini;

--- a/zqa-rag/src/providers/mod.rs
+++ b/zqa-rag/src/providers/mod.rs
@@ -1,0 +1,12 @@
+pub mod anthropic;
+pub mod cohere;
+pub mod gemini;
+pub mod ollama;
+pub mod openai;
+pub mod openrouter;
+pub mod provider_id;
+pub mod registry;
+pub mod voyage;
+pub mod zeroentropy;
+
+pub use provider_id::ProviderId;

--- a/zqa-rag/src/providers/ollama.rs
+++ b/zqa-rag/src/providers/ollama.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use lancedb::embeddings::EmbeddingFunction;
+
+use crate::{
+    capabilities::{EmbeddingFactory, LlmFactory},
+    clients::ollama::OllamaClient,
+    config::LLMClientConfig,
+    embedding::common::EmbeddingProviderConfig,
+    http_client::ReqwestClient,
+    llm::{errors::LLMError, factory::LLMClient},
+    providers::provider_id::ProviderId,
+    vector::lance::{LanceEmbeddingRegistrar, LanceError},
+};
+
+/// Provider descriptor for Ollama capabilities.
+pub struct OllamaProvider;
+
+impl LlmFactory for OllamaProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Ollama
+    }
+
+    fn create_llm(&self, config: &LLMClientConfig) -> Result<LLMClient, LLMError> {
+        let LLMClientConfig::Ollama(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("ollama".into()));
+        };
+
+        Ok(LLMClient::Ollama(OllamaClient::with_config(cfg.clone())))
+    }
+}
+
+impl EmbeddingFactory for OllamaProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Ollama
+    }
+
+    fn create_embedding(
+        &self,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
+        let EmbeddingProviderConfig::Ollama(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("ollama".into()));
+        };
+
+        Ok(Arc::new(OllamaClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl LanceEmbeddingRegistrar for OllamaProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::Ollama
+    }
+
+    fn register_with_lancedb(
+        &self,
+        db: &lancedb::Connection,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<(), LanceError> {
+        let EmbeddingProviderConfig::Ollama(cfg) = config else {
+            return Err(LanceError::ParameterError("Expected Ollama embedding config".into()));
+        };
+
+        db.embedding_registry().register(
+            ProviderId::Ollama.as_str(),
+            Arc::new(OllamaClient::<ReqwestClient>::with_config(cfg.clone())),
+        )?;
+        Ok(())
+    }
+}

--- a/zqa-rag/src/providers/ollama.rs
+++ b/zqa-rag/src/providers/ollama.rs
@@ -1,3 +1,4 @@
+//! Ollama provider implementation
 use std::sync::Arc;
 
 use lancedb::embeddings::EmbeddingFunction;
@@ -60,7 +61,9 @@ impl LanceEmbeddingRegistrar for OllamaProvider {
         config: &EmbeddingProviderConfig,
     ) -> Result<(), LanceError> {
         let EmbeddingProviderConfig::Ollama(cfg) = config else {
-            return Err(LanceError::ParameterError("Expected Ollama embedding config".into()));
+            return Err(LanceError::ParameterError(
+                "Expected Ollama embedding config".into(),
+            ));
         };
 
         db.embedding_registry().register(

--- a/zqa-rag/src/providers/openai.rs
+++ b/zqa-rag/src/providers/openai.rs
@@ -1,3 +1,4 @@
+//! OpenAI provider implementation
 use std::sync::Arc;
 
 use lancedb::embeddings::EmbeddingFunction;
@@ -60,7 +61,9 @@ impl LanceEmbeddingRegistrar for OpenAIProvider {
         config: &EmbeddingProviderConfig,
     ) -> Result<(), LanceError> {
         let EmbeddingProviderConfig::OpenAI(cfg) = config else {
-            return Err(LanceError::ParameterError("Expected OpenAI embedding config".into()));
+            return Err(LanceError::ParameterError(
+                "Expected OpenAI embedding config".into(),
+            ));
         };
 
         db.embedding_registry().register(

--- a/zqa-rag/src/providers/openai.rs
+++ b/zqa-rag/src/providers/openai.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use lancedb::embeddings::EmbeddingFunction;
+
+use crate::{
+    capabilities::{EmbeddingFactory, LlmFactory},
+    clients::openai::OpenAIClient,
+    config::LLMClientConfig,
+    embedding::common::EmbeddingProviderConfig,
+    http_client::ReqwestClient,
+    llm::{errors::LLMError, factory::LLMClient},
+    providers::provider_id::ProviderId,
+    vector::lance::{LanceEmbeddingRegistrar, LanceError},
+};
+
+/// Provider descriptor for OpenAI capabilities.
+pub struct OpenAIProvider;
+
+impl LlmFactory for OpenAIProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::OpenAI
+    }
+
+    fn create_llm(&self, config: &LLMClientConfig) -> Result<LLMClient, LLMError> {
+        let LLMClientConfig::OpenAI(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("openai".into()));
+        };
+
+        Ok(LLMClient::OpenAI(OpenAIClient::with_config(cfg.clone())))
+    }
+}
+
+impl EmbeddingFactory for OpenAIProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::OpenAI
+    }
+
+    fn create_embedding(
+        &self,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
+        let EmbeddingProviderConfig::OpenAI(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("openai".into()));
+        };
+
+        Ok(Arc::new(OpenAIClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl LanceEmbeddingRegistrar for OpenAIProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::OpenAI
+    }
+
+    fn register_with_lancedb(
+        &self,
+        db: &lancedb::Connection,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<(), LanceError> {
+        let EmbeddingProviderConfig::OpenAI(cfg) = config else {
+            return Err(LanceError::ParameterError("Expected OpenAI embedding config".into()));
+        };
+
+        db.embedding_registry().register(
+            ProviderId::OpenAI.as_str(),
+            Arc::new(OpenAIClient::<ReqwestClient>::with_config(cfg.clone())),
+        )?;
+        Ok(())
+    }
+}

--- a/zqa-rag/src/providers/openrouter.rs
+++ b/zqa-rag/src/providers/openrouter.rs
@@ -1,3 +1,4 @@
+//! OpenRouter provider implementation
 use crate::{
     capabilities::LlmFactory,
     clients::openrouter::OpenRouterClient,
@@ -19,6 +20,8 @@ impl LlmFactory for OpenRouterProvider {
             return Err(LLMError::InvalidProviderError("openrouter".into()));
         };
 
-        Ok(LLMClient::OpenRouter(OpenRouterClient::with_config(cfg.clone())))
+        Ok(LLMClient::OpenRouter(OpenRouterClient::with_config(
+            cfg.clone(),
+        )))
     }
 }

--- a/zqa-rag/src/providers/openrouter.rs
+++ b/zqa-rag/src/providers/openrouter.rs
@@ -1,0 +1,24 @@
+use crate::{
+    capabilities::LlmFactory,
+    clients::openrouter::OpenRouterClient,
+    config::LLMClientConfig,
+    llm::{errors::LLMError, factory::LLMClient},
+    providers::provider_id::ProviderId,
+};
+
+/// Provider descriptor for OpenRouter-backed LLM capabilities.
+pub struct OpenRouterProvider;
+
+impl LlmFactory for OpenRouterProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::OpenRouter
+    }
+
+    fn create_llm(&self, config: &LLMClientConfig) -> Result<LLMClient, LLMError> {
+        let LLMClientConfig::OpenRouter(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("openrouter".into()));
+        };
+
+        Ok(LLMClient::OpenRouter(OpenRouterClient::with_config(cfg.clone())))
+    }
+}

--- a/zqa-rag/src/providers/provider_id.rs
+++ b/zqa-rag/src/providers/provider_id.rs
@@ -151,12 +151,18 @@ mod tests {
     fn provider_id_parses_all_supported_names() {
         assert_eq!(ProviderId::from_str("anthropic"), Ok(ProviderId::Anthropic));
         assert_eq!(ProviderId::from_str("openai"), Ok(ProviderId::OpenAI));
-        assert_eq!(ProviderId::from_str("openrouter"), Ok(ProviderId::OpenRouter));
+        assert_eq!(
+            ProviderId::from_str("openrouter"),
+            Ok(ProviderId::OpenRouter)
+        );
         assert_eq!(ProviderId::from_str("gemini"), Ok(ProviderId::Gemini));
         assert_eq!(ProviderId::from_str("ollama"), Ok(ProviderId::Ollama));
         assert_eq!(ProviderId::from_str("voyageai"), Ok(ProviderId::VoyageAI));
         assert_eq!(ProviderId::from_str("cohere"), Ok(ProviderId::Cohere));
-        assert_eq!(ProviderId::from_str("zeroentropy"), Ok(ProviderId::ZeroEntropy));
+        assert_eq!(
+            ProviderId::from_str("zeroentropy"),
+            Ok(ProviderId::ZeroEntropy)
+        );
     }
 
     #[test]
@@ -167,7 +173,10 @@ mod tests {
     #[test]
     fn capability_enums_convert_to_provider_ids() {
         assert_eq!(ProviderId::from(&ModelProvider::OpenAI), ProviderId::OpenAI);
-        assert_eq!(ProviderId::from(&EmbeddingProvider::Gemini), ProviderId::Gemini);
+        assert_eq!(
+            ProviderId::from(&EmbeddingProvider::Gemini),
+            ProviderId::Gemini
+        );
         assert_eq!(
             ProviderId::from(&RerankerProvider::ZeroEntropy),
             ProviderId::ZeroEntropy

--- a/zqa-rag/src/providers/provider_id.rs
+++ b/zqa-rag/src/providers/provider_id.rs
@@ -1,0 +1,26 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProviderId {
+    Anthropic,
+    OpenAI,
+    OpenRouter,
+    Gemini,
+    Ollama,
+    VoyageAI,
+    Cohere,
+    ZeroEntropy,
+}
+
+impl ProviderId {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Anthropic => "anthropic",
+            Self::OpenAI => "openai",
+            Self::OpenRouter => "openrouter",
+            Self::Gemini => "gemini",
+            Self::Ollama => "ollama",
+            Self::VoyageAI => "voyageai",
+            Self::Cohere => "cohere",
+            Self::ZeroEntropy => "zeroentropy",
+        }
+    }
+}

--- a/zqa-rag/src/providers/provider_id.rs
+++ b/zqa-rag/src/providers/provider_id.rs
@@ -1,4 +1,9 @@
+//! Canonical identifiers for each provider
+
+/// The canonical list of providers, regardless of capabilities. The
+/// [`super::registry::ProviderRegistry`] is responsible for maintaining that information.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
 pub enum ProviderId {
     Anthropic,
     OpenAI,
@@ -11,6 +16,8 @@ pub enum ProviderId {
 }
 
 impl ProviderId {
+    /// Return a canonical string representation for a provider
+    #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Anthropic => "anthropic",

--- a/zqa-rag/src/providers/provider_id.rs
+++ b/zqa-rag/src/providers/provider_id.rs
@@ -1,5 +1,9 @@
 //! Canonical identifiers for each provider
 
+use std::str::FromStr;
+
+use crate::capabilities::{EmbeddingProvider, ModelProvider, RerankerProvider};
+
 /// The canonical list of providers, regardless of capabilities. The
 /// [`super::registry::ProviderRegistry`] is responsible for maintaining that information.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -15,6 +19,12 @@ pub enum ProviderId {
     ZeroEntropy,
 }
 
+impl std::fmt::Display for ProviderId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl ProviderId {
     /// Return a canonical string representation for a provider
     #[must_use]
@@ -28,6 +38,89 @@ impl ProviderId {
             Self::VoyageAI => "voyageai",
             Self::Cohere => "cohere",
             Self::ZeroEntropy => "zeroentropy",
+        }
+    }
+}
+
+impl FromStr for ProviderId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "anthropic" => Ok(ProviderId::Anthropic),
+            "openai" => Ok(Self::OpenAI),
+            "openrouter" => Ok(Self::OpenRouter),
+            "gemini" => Ok(Self::Gemini),
+            "ollama" => Ok(Self::Ollama),
+            "voyageai" => Ok(Self::VoyageAI),
+            "cohere" => Ok(Self::Cohere),
+            "zeroentropy" => Ok(Self::ZeroEntropy),
+            _ => Err(format!("Invalid provider name: {s}")),
+        }
+    }
+}
+
+impl From<ModelProvider> for ProviderId {
+    fn from(value: ModelProvider) -> Self {
+        Self::from_str(value.as_str())
+            .expect("ModelProvider instances contain valid provider names.")
+    }
+}
+
+impl From<EmbeddingProvider> for ProviderId {
+    fn from(value: EmbeddingProvider) -> Self {
+        Self::from_str(value.as_str())
+            .expect("EmbeddingProvider instances contain valid provider names.")
+    }
+}
+
+impl From<RerankerProvider> for ProviderId {
+    fn from(value: RerankerProvider) -> Self {
+        Self::from_str(value.as_str())
+            .expect("RerankerProvider instances contain valid provider names.")
+    }
+}
+
+impl TryFrom<ProviderId> for EmbeddingProvider {
+    type Error = String;
+
+    fn try_from(value: ProviderId) -> Result<Self, Self::Error> {
+        match value {
+            ProviderId::VoyageAI => Ok(EmbeddingProvider::VoyageAI),
+            ProviderId::ZeroEntropy => Ok(EmbeddingProvider::ZeroEntropy),
+            ProviderId::Gemini => Ok(EmbeddingProvider::Gemini),
+            ProviderId::OpenAI => Ok(EmbeddingProvider::OpenAI),
+            ProviderId::Ollama => Ok(EmbeddingProvider::Ollama),
+            ProviderId::Cohere => Ok(EmbeddingProvider::Cohere),
+            _ => Err(format!("Provider {value} does not support embedding.")),
+        }
+    }
+}
+
+impl TryFrom<ProviderId> for RerankerProvider {
+    type Error = String;
+
+    fn try_from(value: ProviderId) -> Result<Self, Self::Error> {
+        match value {
+            ProviderId::VoyageAI => Ok(RerankerProvider::VoyageAI),
+            ProviderId::ZeroEntropy => Ok(RerankerProvider::ZeroEntropy),
+            ProviderId::Cohere => Ok(RerankerProvider::Cohere),
+            _ => Err(format!("Provider {value} does not support reranking.")),
+        }
+    }
+}
+
+impl TryFrom<ProviderId> for ModelProvider {
+    type Error = String;
+
+    fn try_from(value: ProviderId) -> Result<Self, Self::Error> {
+        match value {
+            ProviderId::Gemini => Ok(ModelProvider::Gemini),
+            ProviderId::Ollama => Ok(ModelProvider::Ollama),
+            ProviderId::OpenAI => Ok(ModelProvider::OpenAI),
+            ProviderId::Anthropic => Ok(ModelProvider::Anthropic),
+            ProviderId::OpenRouter => Ok(ModelProvider::OpenRouter),
+            _ => Err(format!("Provider {value} does not support generation.")),
         }
     }
 }

--- a/zqa-rag/src/providers/provider_id.rs
+++ b/zqa-rag/src/providers/provider_id.rs
@@ -60,24 +60,38 @@ impl FromStr for ProviderId {
     }
 }
 
-impl From<ModelProvider> for ProviderId {
-    fn from(value: ModelProvider) -> Self {
-        Self::from_str(value.as_str())
-            .expect("ModelProvider instances contain valid provider names.")
+impl From<&ModelProvider> for ProviderId {
+    fn from(value: &ModelProvider) -> Self {
+        match value {
+            ModelProvider::Anthropic => Self::Anthropic,
+            ModelProvider::Ollama => Self::Ollama,
+            ModelProvider::OpenAI => Self::OpenAI,
+            ModelProvider::OpenRouter => Self::OpenRouter,
+            ModelProvider::Gemini => Self::Gemini,
+        }
     }
 }
 
-impl From<EmbeddingProvider> for ProviderId {
-    fn from(value: EmbeddingProvider) -> Self {
-        Self::from_str(value.as_str())
-            .expect("EmbeddingProvider instances contain valid provider names.")
+impl From<&EmbeddingProvider> for ProviderId {
+    fn from(value: &EmbeddingProvider) -> Self {
+        match value {
+            EmbeddingProvider::Cohere => Self::Cohere,
+            EmbeddingProvider::OpenAI => Self::OpenAI,
+            EmbeddingProvider::Ollama => Self::Ollama,
+            EmbeddingProvider::VoyageAI => Self::VoyageAI,
+            EmbeddingProvider::Gemini => Self::Gemini,
+            EmbeddingProvider::ZeroEntropy => Self::ZeroEntropy,
+        }
     }
 }
 
-impl From<RerankerProvider> for ProviderId {
-    fn from(value: RerankerProvider) -> Self {
-        Self::from_str(value.as_str())
-            .expect("RerankerProvider instances contain valid provider names.")
+impl From<&RerankerProvider> for ProviderId {
+    fn from(value: &RerankerProvider) -> Self {
+        match value {
+            RerankerProvider::Cohere => Self::Cohere,
+            RerankerProvider::VoyageAI => Self::VoyageAI,
+            RerankerProvider::ZeroEntropy => Self::ZeroEntropy,
+        }
     }
 }
 
@@ -122,5 +136,64 @@ impl TryFrom<ProviderId> for ModelProvider {
             ProviderId::OpenRouter => Ok(ModelProvider::OpenRouter),
             _ => Err(format!("Provider {value} does not support generation.")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::capabilities::{EmbeddingProvider, ModelProvider, RerankerProvider};
+
+    use super::ProviderId;
+
+    #[test]
+    fn provider_id_parses_all_supported_names() {
+        assert_eq!(ProviderId::from_str("anthropic"), Ok(ProviderId::Anthropic));
+        assert_eq!(ProviderId::from_str("openai"), Ok(ProviderId::OpenAI));
+        assert_eq!(ProviderId::from_str("openrouter"), Ok(ProviderId::OpenRouter));
+        assert_eq!(ProviderId::from_str("gemini"), Ok(ProviderId::Gemini));
+        assert_eq!(ProviderId::from_str("ollama"), Ok(ProviderId::Ollama));
+        assert_eq!(ProviderId::from_str("voyageai"), Ok(ProviderId::VoyageAI));
+        assert_eq!(ProviderId::from_str("cohere"), Ok(ProviderId::Cohere));
+        assert_eq!(ProviderId::from_str("zeroentropy"), Ok(ProviderId::ZeroEntropy));
+    }
+
+    #[test]
+    fn provider_id_rejects_invalid_names() {
+        assert!(ProviderId::from_str("not-a-provider").is_err());
+    }
+
+    #[test]
+    fn capability_enums_convert_to_provider_ids() {
+        assert_eq!(ProviderId::from(&ModelProvider::OpenAI), ProviderId::OpenAI);
+        assert_eq!(ProviderId::from(&EmbeddingProvider::Gemini), ProviderId::Gemini);
+        assert_eq!(
+            ProviderId::from(&RerankerProvider::ZeroEntropy),
+            ProviderId::ZeroEntropy
+        );
+    }
+
+    #[test]
+    fn provider_ids_convert_to_supported_capability_enums() {
+        assert_eq!(
+            EmbeddingProvider::try_from(ProviderId::OpenAI),
+            Ok(EmbeddingProvider::OpenAI)
+        );
+        assert_eq!(
+            RerankerProvider::try_from(ProviderId::Cohere),
+            Ok(RerankerProvider::Cohere)
+        );
+        assert_eq!(
+            ModelProvider::try_from(ProviderId::Anthropic),
+            Ok(ModelProvider::Anthropic)
+        );
+    }
+
+    #[test]
+    fn provider_ids_reject_unsupported_capability_conversions() {
+        assert!(EmbeddingProvider::try_from(ProviderId::Anthropic).is_err());
+        assert!(RerankerProvider::try_from(ProviderId::OpenAI).is_err());
+        assert!(ModelProvider::try_from(ProviderId::VoyageAI).is_err());
     }
 }

--- a/zqa-rag/src/providers/registry.rs
+++ b/zqa-rag/src/providers/registry.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, sync::Arc};
+//! Registry for providers
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+};
 
 use lancedb::embeddings::EmbeddingFunction;
 
@@ -18,9 +22,13 @@ use crate::{
 
 /// Registry for provider factories keyed by canonical provider ID.
 pub struct ProviderRegistry {
+    /// Mappings from LLM providers to corresponding factory methods
     llm: HashMap<ProviderId, Arc<dyn LlmFactory>>,
+    /// Mappings from embedding providers to corresponding factory methods
     embedding: HashMap<ProviderId, Arc<dyn EmbeddingFactory>>,
+    /// Mappings from reranking providers to corresponding factory methods
     rerank: HashMap<ProviderId, Arc<dyn RerankFactory>>,
+    /// Mappings from LanceDB embedding providers to corresponding factory methods
     lance_embedding: HashMap<ProviderId, Arc<dyn LanceEmbeddingRegistrar>>,
 }
 
@@ -165,9 +173,17 @@ pub fn default_provider_registry() -> ProviderRegistry {
     registry
 }
 
+static DEFAULT_REGISTRY: LazyLock<ProviderRegistry> = LazyLock::new(default_provider_registry);
+
+/// Get the default provider registry.
+#[must_use]
+pub fn provider_registry() -> &'static ProviderRegistry {
+    &DEFAULT_REGISTRY
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ProviderRegistry, default_provider_registry};
+    use super::ProviderRegistry;
     use crate::{
         config::{
             AnthropicConfig, CohereConfig, GeminiConfig, OllamaConfig, OpenAIConfig,
@@ -175,6 +191,7 @@ mod tests {
         },
         embedding::common::EmbeddingProviderConfig,
         llm::factory::LLMClient,
+        providers::registry::provider_registry,
         reranking::common::RerankProviderConfig,
         vector::lance::LanceError,
     };
@@ -308,34 +325,77 @@ mod tests {
 
     #[test]
     fn default_registry_creates_all_llm_clients() {
-        let registry = default_provider_registry();
+        let registry = provider_registry();
 
-        assert!(matches!(registry.create_llm(&anthropic_llm_config()), Ok(LLMClient::Anthropic(_))));
-        assert!(matches!(registry.create_llm(&openai_llm_config()), Ok(LLMClient::OpenAI(_))));
-        assert!(matches!(registry.create_llm(&openrouter_llm_config()), Ok(LLMClient::OpenRouter(_))));
-        assert!(matches!(registry.create_llm(&gemini_llm_config()), Ok(LLMClient::Gemini(_))));
-        assert!(matches!(registry.create_llm(&ollama_llm_config()), Ok(LLMClient::Ollama(_))));
+        assert!(matches!(
+            registry.create_llm(&anthropic_llm_config()),
+            Ok(LLMClient::Anthropic(_))
+        ));
+        assert!(matches!(
+            registry.create_llm(&openai_llm_config()),
+            Ok(LLMClient::OpenAI(_))
+        ));
+        assert!(matches!(
+            registry.create_llm(&openrouter_llm_config()),
+            Ok(LLMClient::OpenRouter(_))
+        ));
+        assert!(matches!(
+            registry.create_llm(&gemini_llm_config()),
+            Ok(LLMClient::Gemini(_))
+        ));
+        assert!(matches!(
+            registry.create_llm(&ollama_llm_config()),
+            Ok(LLMClient::Ollama(_))
+        ));
     }
 
     #[test]
     fn default_registry_creates_all_embedding_clients() {
-        let registry = default_provider_registry();
+        let registry = provider_registry();
 
-        assert!(registry.create_embedding(&openai_embedding_config()).is_ok());
-        assert!(registry.create_embedding(&voyage_embedding_config()).is_ok());
-        assert!(registry.create_embedding(&cohere_embedding_config()).is_ok());
-        assert!(registry.create_embedding(&zeroentropy_embedding_config()).is_ok());
-        assert!(registry.create_embedding(&gemini_embedding_config()).is_ok());
-        assert!(registry.create_embedding(&ollama_embedding_config()).is_ok());
+        assert!(
+            registry
+                .create_embedding(&openai_embedding_config())
+                .is_ok()
+        );
+        assert!(
+            registry
+                .create_embedding(&voyage_embedding_config())
+                .is_ok()
+        );
+        assert!(
+            registry
+                .create_embedding(&cohere_embedding_config())
+                .is_ok()
+        );
+        assert!(
+            registry
+                .create_embedding(&zeroentropy_embedding_config())
+                .is_ok()
+        );
+        assert!(
+            registry
+                .create_embedding(&gemini_embedding_config())
+                .is_ok()
+        );
+        assert!(
+            registry
+                .create_embedding(&ollama_embedding_config())
+                .is_ok()
+        );
     }
 
     #[test]
     fn default_registry_creates_all_rerank_clients() {
-        let registry = default_provider_registry();
+        let registry = provider_registry();
 
         assert!(registry.create_reranker(&voyage_rerank_config()).is_ok());
         assert!(registry.create_reranker(&cohere_rerank_config()).is_ok());
-        assert!(registry.create_reranker(&zeroentropy_rerank_config()).is_ok());
+        assert!(
+            registry
+                .create_reranker(&zeroentropy_rerank_config())
+                .is_ok()
+        );
     }
 
     #[test]

--- a/zqa-rag/src/providers/registry.rs
+++ b/zqa-rag/src/providers/registry.rs
@@ -1,0 +1,388 @@
+use std::{collections::HashMap, sync::Arc};
+
+use lancedb::embeddings::EmbeddingFunction;
+
+use crate::{
+    capabilities::{EmbeddingFactory, LlmFactory, RerankFactory},
+    config::LLMClientConfig,
+    embedding::common::EmbeddingProviderConfig,
+    llm::{errors::LLMError, factory::LLMClient},
+    providers::{
+        anthropic::AnthropicProvider, cohere::CohereProvider, gemini::GeminiProvider,
+        ollama::OllamaProvider, openai::OpenAIProvider, openrouter::OpenRouterProvider,
+        provider_id::ProviderId, voyage::VoyageAIProvider, zeroentropy::ZeroEntropyProvider,
+    },
+    reranking::common::{Rerank, RerankProviderConfig},
+    vector::lance::{LanceEmbeddingRegistrar, LanceError},
+};
+
+/// Registry for provider factories keyed by canonical provider ID.
+pub struct ProviderRegistry {
+    llm: HashMap<ProviderId, Arc<dyn LlmFactory>>,
+    embedding: HashMap<ProviderId, Arc<dyn EmbeddingFactory>>,
+    rerank: HashMap<ProviderId, Arc<dyn RerankFactory>>,
+    lance_embedding: HashMap<ProviderId, Arc<dyn LanceEmbeddingRegistrar>>,
+}
+
+impl ProviderRegistry {
+    /// Create an empty provider registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            llm: HashMap::new(),
+            embedding: HashMap::new(),
+            rerank: HashMap::new(),
+            lance_embedding: HashMap::new(),
+        }
+    }
+
+    /// Register an LLM factory.
+    pub fn register_llm(&mut self, factory: Arc<dyn LlmFactory>) {
+        self.llm.insert(factory.provider_id(), factory);
+    }
+
+    /// Register an embedding factory.
+    pub fn register_embedding(&mut self, factory: Arc<dyn EmbeddingFactory>) {
+        self.embedding.insert(factory.provider_id(), factory);
+    }
+
+    /// Register a reranking factory.
+    pub fn register_rerank(&mut self, factory: Arc<dyn RerankFactory>) {
+        self.rerank.insert(factory.provider_id(), factory);
+    }
+
+    /// Register a LanceDB embedding registrar.
+    pub fn register_lance_embedding(&mut self, registrar: Arc<dyn LanceEmbeddingRegistrar>) {
+        self.lance_embedding
+            .insert(registrar.provider_id(), registrar);
+    }
+
+    /// Create an LLM client from provider-specific config.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the provider is not registered or client creation fails.
+    pub fn create_llm(&self, config: &LLMClientConfig) -> Result<LLMClient, LLMError> {
+        let provider = config.provider_id();
+        let factory = self
+            .llm
+            .get(&provider)
+            .ok_or_else(|| LLMError::InvalidProviderError(provider.as_str().to_string()))?;
+        factory.create_llm(config)
+    }
+
+    /// Create an embedding client from provider-specific config.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the provider is not registered or client creation fails.
+    pub fn create_embedding(
+        &self,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
+        let provider = config.provider_id();
+        let factory = self
+            .embedding
+            .get(&provider)
+            .ok_or_else(|| LLMError::InvalidProviderError(provider.as_str().to_string()))?;
+        factory.create_embedding(config)
+    }
+
+    /// Create a reranker from provider-specific config.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the provider is not registered or client creation fails.
+    pub fn create_reranker(
+        &self,
+        config: &RerankProviderConfig,
+    ) -> Result<Arc<dyn Rerank>, LLMError> {
+        let provider = config.provider_id();
+        let factory = self
+            .rerank
+            .get(&provider)
+            .ok_or_else(|| LLMError::InvalidProviderError(provider.as_str().to_string()))?;
+        factory.create_reranker(config)
+    }
+
+    /// Register the provider's embedding implementation with LanceDB.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no LanceDB registrar exists for the provider or if registration fails.
+    pub fn register_embedding_with_lancedb(
+        &self,
+        db: &lancedb::Connection,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<(), LanceError> {
+        let provider = config.provider_id();
+        let registrar = self.lance_embedding.get(&provider).ok_or_else(|| {
+            LanceError::ParameterError(format!(
+                "{} does not support LanceDB embedding registration",
+                provider.as_str()
+            ))
+        })?;
+
+        registrar.register_with_lancedb(db, config)
+    }
+}
+
+impl Default for ProviderRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Construct the default provider registry used by the crate.
+#[must_use]
+pub fn default_provider_registry() -> ProviderRegistry {
+    let mut registry = ProviderRegistry::new();
+
+    registry.register_llm(Arc::new(AnthropicProvider));
+    registry.register_llm(Arc::new(OpenAIProvider));
+    registry.register_llm(Arc::new(OpenRouterProvider));
+    registry.register_llm(Arc::new(GeminiProvider));
+    registry.register_llm(Arc::new(OllamaProvider));
+
+    registry.register_embedding(Arc::new(OpenAIProvider));
+    registry.register_embedding(Arc::new(VoyageAIProvider));
+    registry.register_embedding(Arc::new(CohereProvider));
+    registry.register_embedding(Arc::new(ZeroEntropyProvider));
+    registry.register_embedding(Arc::new(GeminiProvider));
+    registry.register_embedding(Arc::new(OllamaProvider));
+
+    registry.register_rerank(Arc::new(VoyageAIProvider));
+    registry.register_rerank(Arc::new(CohereProvider));
+    registry.register_rerank(Arc::new(ZeroEntropyProvider));
+
+    registry.register_lance_embedding(Arc::new(OpenAIProvider));
+    registry.register_lance_embedding(Arc::new(VoyageAIProvider));
+    registry.register_lance_embedding(Arc::new(CohereProvider));
+    registry.register_lance_embedding(Arc::new(ZeroEntropyProvider));
+    registry.register_lance_embedding(Arc::new(GeminiProvider));
+    registry.register_lance_embedding(Arc::new(OllamaProvider));
+
+    registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProviderRegistry, default_provider_registry};
+    use crate::{
+        config::{
+            AnthropicConfig, CohereConfig, GeminiConfig, OllamaConfig, OpenAIConfig,
+            OpenRouterConfig, VoyageAIConfig, ZeroEntropyConfig,
+        },
+        embedding::common::EmbeddingProviderConfig,
+        llm::factory::LLMClient,
+        reranking::common::RerankProviderConfig,
+        vector::lance::LanceError,
+    };
+
+    fn openai_llm_config() -> crate::config::LLMClientConfig {
+        crate::config::LLMClientConfig::OpenAI(OpenAIConfig {
+            api_key: "test-key".into(),
+            model: "gpt-test".into(),
+            max_tokens: 1024,
+            embedding_model: "text-embedding-test".into(),
+            embedding_dims: 1536,
+        })
+    }
+
+    fn anthropic_llm_config() -> crate::config::LLMClientConfig {
+        crate::config::LLMClientConfig::Anthropic(AnthropicConfig {
+            api_key: "test-key".into(),
+            model: "claude-test".into(),
+            max_tokens: 1024,
+        })
+    }
+
+    fn gemini_llm_config() -> crate::config::LLMClientConfig {
+        crate::config::LLMClientConfig::Gemini(GeminiConfig {
+            api_key: "test-key".into(),
+            model: "gemini-test".into(),
+            embedding_model: "gemini-embedding-test".into(),
+            embedding_dims: 3072,
+        })
+    }
+
+    fn ollama_llm_config() -> crate::config::LLMClientConfig {
+        crate::config::LLMClientConfig::Ollama(OllamaConfig {
+            model: "qwen-test".into(),
+            max_tokens: 1024,
+            embedding_model: "qwen-embedding-test".into(),
+            embedding_dims: 768,
+            base_url: "http://127.0.0.1:11434".into(),
+        })
+    }
+
+    fn openrouter_llm_config() -> crate::config::LLMClientConfig {
+        crate::config::LLMClientConfig::OpenRouter(OpenRouterConfig {
+            api_key: "test-key".into(),
+            model: "anthropic/test-model".into(),
+        })
+    }
+
+    fn openai_embedding_config() -> EmbeddingProviderConfig {
+        EmbeddingProviderConfig::OpenAI(OpenAIConfig {
+            api_key: "test-key".into(),
+            model: "gpt-test".into(),
+            max_tokens: 1024,
+            embedding_model: "text-embedding-test".into(),
+            embedding_dims: 1536,
+        })
+    }
+
+    fn gemini_embedding_config() -> EmbeddingProviderConfig {
+        EmbeddingProviderConfig::Gemini(GeminiConfig {
+            api_key: "test-key".into(),
+            model: "gemini-test".into(),
+            embedding_model: "gemini-embedding-test".into(),
+            embedding_dims: 3072,
+        })
+    }
+
+    fn ollama_embedding_config() -> EmbeddingProviderConfig {
+        EmbeddingProviderConfig::Ollama(OllamaConfig {
+            model: "qwen-test".into(),
+            max_tokens: 1024,
+            embedding_model: "qwen-embedding-test".into(),
+            embedding_dims: 768,
+            base_url: "http://127.0.0.1:11434".into(),
+        })
+    }
+
+    fn voyage_embedding_config() -> EmbeddingProviderConfig {
+        EmbeddingProviderConfig::VoyageAI(VoyageAIConfig {
+            api_key: "test-key".into(),
+            embedding_model: "voyage-test".into(),
+            embedding_dims: 1024,
+            reranker: "rerank-test".into(),
+        })
+    }
+
+    fn cohere_embedding_config() -> EmbeddingProviderConfig {
+        EmbeddingProviderConfig::Cohere(CohereConfig {
+            api_key: "test-key".into(),
+            embedding_model: "embed-test".into(),
+            embedding_dims: 1024,
+            reranker: "rerank-test".into(),
+        })
+    }
+
+    fn zeroentropy_embedding_config() -> EmbeddingProviderConfig {
+        EmbeddingProviderConfig::ZeroEntropy(ZeroEntropyConfig {
+            api_key: "test-key".into(),
+            embedding_model: "zembed-test".into(),
+            embedding_dims: 1024,
+            reranker: "zerank-test".into(),
+        })
+    }
+
+    fn voyage_rerank_config() -> RerankProviderConfig {
+        RerankProviderConfig::VoyageAI(VoyageAIConfig {
+            api_key: "test-key".into(),
+            embedding_model: "voyage-test".into(),
+            embedding_dims: 1024,
+            reranker: "rerank-test".into(),
+        })
+    }
+
+    fn cohere_rerank_config() -> RerankProviderConfig {
+        RerankProviderConfig::Cohere(CohereConfig {
+            api_key: "test-key".into(),
+            embedding_model: "embed-test".into(),
+            embedding_dims: 1024,
+            reranker: "rerank-test".into(),
+        })
+    }
+
+    fn zeroentropy_rerank_config() -> RerankProviderConfig {
+        RerankProviderConfig::ZeroEntropy(ZeroEntropyConfig {
+            api_key: "test-key".into(),
+            embedding_model: "zembed-test".into(),
+            embedding_dims: 1024,
+            reranker: "zerank-test".into(),
+        })
+    }
+
+    #[test]
+    fn default_registry_creates_all_llm_clients() {
+        let registry = default_provider_registry();
+
+        assert!(matches!(registry.create_llm(&anthropic_llm_config()), Ok(LLMClient::Anthropic(_))));
+        assert!(matches!(registry.create_llm(&openai_llm_config()), Ok(LLMClient::OpenAI(_))));
+        assert!(matches!(registry.create_llm(&openrouter_llm_config()), Ok(LLMClient::OpenRouter(_))));
+        assert!(matches!(registry.create_llm(&gemini_llm_config()), Ok(LLMClient::Gemini(_))));
+        assert!(matches!(registry.create_llm(&ollama_llm_config()), Ok(LLMClient::Ollama(_))));
+    }
+
+    #[test]
+    fn default_registry_creates_all_embedding_clients() {
+        let registry = default_provider_registry();
+
+        assert!(registry.create_embedding(&openai_embedding_config()).is_ok());
+        assert!(registry.create_embedding(&voyage_embedding_config()).is_ok());
+        assert!(registry.create_embedding(&cohere_embedding_config()).is_ok());
+        assert!(registry.create_embedding(&zeroentropy_embedding_config()).is_ok());
+        assert!(registry.create_embedding(&gemini_embedding_config()).is_ok());
+        assert!(registry.create_embedding(&ollama_embedding_config()).is_ok());
+    }
+
+    #[test]
+    fn default_registry_creates_all_rerank_clients() {
+        let registry = default_provider_registry();
+
+        assert!(registry.create_reranker(&voyage_rerank_config()).is_ok());
+        assert!(registry.create_reranker(&cohere_rerank_config()).is_ok());
+        assert!(registry.create_reranker(&zeroentropy_rerank_config()).is_ok());
+    }
+
+    #[test]
+    fn empty_registry_rejects_unregistered_llm_provider() {
+        let registry = ProviderRegistry::new();
+        let result = registry.create_llm(&openai_llm_config());
+
+        assert!(matches!(
+            result,
+            Err(crate::llm::errors::LLMError::InvalidProviderError(provider)) if provider == "openai"
+        ));
+    }
+
+    #[test]
+    fn empty_registry_rejects_unregistered_embedding_provider() {
+        let registry = ProviderRegistry::new();
+        let result = registry.create_embedding(&openai_embedding_config());
+
+        assert!(matches!(
+            result,
+            Err(crate::llm::errors::LLMError::InvalidProviderError(provider)) if provider == "openai"
+        ));
+    }
+
+    #[test]
+    fn empty_registry_rejects_unregistered_rerank_provider() {
+        let registry = ProviderRegistry::new();
+        let result = registry.create_reranker(&voyage_rerank_config());
+
+        assert!(matches!(
+            result,
+            Err(crate::llm::errors::LLMError::InvalidProviderError(provider)) if provider == "voyageai"
+        ));
+    }
+
+    #[tokio::test]
+    async fn empty_registry_rejects_lancedb_registration_for_unregistered_provider() {
+        let registry = ProviderRegistry::new();
+        let db = lancedb::connect("memory://test-registry")
+            .execute()
+            .await
+            .expect("memory db should be created");
+        let result = registry.register_embedding_with_lancedb(&db, &openai_embedding_config());
+
+        assert!(matches!(
+            result,
+            Err(LanceError::ParameterError(message)) if message.contains("openai")
+        ));
+    }
+}

--- a/zqa-rag/src/providers/voyage.rs
+++ b/zqa-rag/src/providers/voyage.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use lancedb::embeddings::EmbeddingFunction;
+
+use crate::{
+    capabilities::{EmbeddingFactory, RerankFactory},
+    embedding::{common::EmbeddingProviderConfig, voyage::VoyageAIClient},
+    http_client::ReqwestClient,
+    llm::errors::LLMError,
+    providers::provider_id::ProviderId,
+    reranking::common::{Rerank, RerankProviderConfig},
+    vector::lance::{LanceEmbeddingRegistrar, LanceError},
+};
+
+/// Provider descriptor for Voyage AI capabilities.
+pub struct VoyageAIProvider;
+
+impl EmbeddingFactory for VoyageAIProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::VoyageAI
+    }
+
+    fn create_embedding(
+        &self,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
+        let EmbeddingProviderConfig::VoyageAI(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("voyageai".into()));
+        };
+
+        Ok(Arc::new(VoyageAIClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl RerankFactory for VoyageAIProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::VoyageAI
+    }
+
+    fn create_reranker(&self, config: &RerankProviderConfig) -> Result<Arc<dyn Rerank>, LLMError> {
+        let RerankProviderConfig::VoyageAI(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("voyageai".into()));
+        };
+
+        Ok(Arc::new(VoyageAIClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl LanceEmbeddingRegistrar for VoyageAIProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::VoyageAI
+    }
+
+    fn register_with_lancedb(
+        &self,
+        db: &lancedb::Connection,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<(), LanceError> {
+        let EmbeddingProviderConfig::VoyageAI(cfg) = config else {
+            return Err(LanceError::ParameterError("Expected VoyageAI embedding config".into()));
+        };
+
+        db.embedding_registry().register(
+            ProviderId::VoyageAI.as_str(),
+            Arc::new(VoyageAIClient::<ReqwestClient>::with_config(cfg.clone())),
+        )?;
+        Ok(())
+    }
+}

--- a/zqa-rag/src/providers/voyage.rs
+++ b/zqa-rag/src/providers/voyage.rs
@@ -1,3 +1,4 @@
+//! Voyage AI provider implementation
 use std::sync::Arc;
 
 use lancedb::embeddings::EmbeddingFunction;
@@ -61,7 +62,9 @@ impl LanceEmbeddingRegistrar for VoyageAIProvider {
         config: &EmbeddingProviderConfig,
     ) -> Result<(), LanceError> {
         let EmbeddingProviderConfig::VoyageAI(cfg) = config else {
-            return Err(LanceError::ParameterError("Expected VoyageAI embedding config".into()));
+            return Err(LanceError::ParameterError(
+                "Expected VoyageAI embedding config".into(),
+            ));
         };
 
         db.embedding_registry().register(

--- a/zqa-rag/src/providers/zeroentropy.rs
+++ b/zqa-rag/src/providers/zeroentropy.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use lancedb::embeddings::EmbeddingFunction;
+
+use crate::{
+    capabilities::{EmbeddingFactory, RerankFactory},
+    embedding::{common::EmbeddingProviderConfig, zeroentropy::ZeroEntropyClient},
+    http_client::ReqwestClient,
+    llm::errors::LLMError,
+    providers::provider_id::ProviderId,
+    reranking::common::{Rerank, RerankProviderConfig},
+    vector::lance::{LanceEmbeddingRegistrar, LanceError},
+};
+
+/// Provider descriptor for ZeroEntropy capabilities.
+pub struct ZeroEntropyProvider;
+
+impl EmbeddingFactory for ZeroEntropyProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::ZeroEntropy
+    }
+
+    fn create_embedding(
+        &self,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<Arc<dyn EmbeddingFunction>, LLMError> {
+        let EmbeddingProviderConfig::ZeroEntropy(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("zeroentropy".into()));
+        };
+
+        Ok(Arc::new(ZeroEntropyClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl RerankFactory for ZeroEntropyProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::ZeroEntropy
+    }
+
+    fn create_reranker(&self, config: &RerankProviderConfig) -> Result<Arc<dyn Rerank>, LLMError> {
+        let RerankProviderConfig::ZeroEntropy(cfg) = config else {
+            return Err(LLMError::InvalidProviderError("zeroentropy".into()));
+        };
+
+        Ok(Arc::new(ZeroEntropyClient::<ReqwestClient>::with_config(
+            cfg.clone(),
+        )))
+    }
+}
+
+impl LanceEmbeddingRegistrar for ZeroEntropyProvider {
+    fn provider_id(&self) -> ProviderId {
+        ProviderId::ZeroEntropy
+    }
+
+    fn register_with_lancedb(
+        &self,
+        db: &lancedb::Connection,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<(), LanceError> {
+        let EmbeddingProviderConfig::ZeroEntropy(cfg) = config else {
+            return Err(LanceError::ParameterError(
+                "Expected ZeroEntropy embedding config".into(),
+            ));
+        };
+
+        db.embedding_registry().register(
+            ProviderId::ZeroEntropy.as_str(),
+            Arc::new(ZeroEntropyClient::<ReqwestClient>::with_config(cfg.clone())),
+        )?;
+        Ok(())
+    }
+}

--- a/zqa-rag/src/providers/zeroentropy.rs
+++ b/zqa-rag/src/providers/zeroentropy.rs
@@ -1,3 +1,4 @@
+//! ZeroEntropy provider implementation
 use std::sync::Arc;
 
 use lancedb::embeddings::EmbeddingFunction;

--- a/zqa-rag/src/reranking/common.rs
+++ b/zqa-rag/src/reranking/common.rs
@@ -7,6 +7,7 @@ use crate::{
     embedding::{cohere::CohereClient, voyage::VoyageAIClient, zeroentropy::ZeroEntropyClient},
     http_client::ReqwestClient,
     llm::errors::LLMError,
+    providers::{ProviderId, registry::default_provider_registry},
 };
 
 /// A trait indicating reranking capabilities.
@@ -66,17 +67,7 @@ pub fn get_reranking_provider(provider: RerankerProvider) -> Arc<dyn Rerank> {
 pub fn get_reranking_provider_with_config(
     config: RerankProviderConfig,
 ) -> Result<Arc<dyn Rerank>, LLMError> {
-    match config {
-        RerankProviderConfig::VoyageAI(cfg) => {
-            Ok(Arc::new(VoyageAIClient::<ReqwestClient>::with_config(cfg)))
-        }
-        RerankProviderConfig::Cohere(cfg) => {
-            Ok(Arc::new(CohereClient::<ReqwestClient>::with_config(cfg)))
-        }
-        RerankProviderConfig::ZeroEntropy(cfg) => Ok(Arc::new(
-            ZeroEntropyClient::<ReqwestClient>::with_config(cfg),
-        )),
-    }
+    default_provider_registry().create_reranker(&config)
 }
 
 /// Configuration enum for reranking providers
@@ -91,6 +82,14 @@ pub enum RerankProviderConfig {
 }
 
 impl RerankProviderConfig {
+    pub const fn provider_id(&self) -> ProviderId {
+        match self {
+            Self::VoyageAI(_) => ProviderId::VoyageAI,
+            Self::Cohere(_) => ProviderId::Cohere,
+            Self::ZeroEntropy(_) => ProviderId::ZeroEntropy,
+        }
+    }
+
     /// Return the provider (enum)
     #[must_use]
     pub fn provider(&self) -> RerankerProvider {

--- a/zqa-rag/src/reranking/common.rs
+++ b/zqa-rag/src/reranking/common.rs
@@ -7,7 +7,7 @@ use crate::{
     embedding::{cohere::CohereClient, voyage::VoyageAIClient, zeroentropy::ZeroEntropyClient},
     http_client::ReqwestClient,
     llm::errors::LLMError,
-    providers::{ProviderId, registry::default_provider_registry},
+    providers::{ProviderId, registry::provider_registry},
 };
 
 /// A trait indicating reranking capabilities.
@@ -65,9 +65,9 @@ pub fn get_reranking_provider(provider: RerankerProvider) -> Arc<dyn Rerank> {
 ///
 /// Returns an error if provider configuration is invalid or initialization fails.
 pub fn get_reranking_provider_with_config(
-    config: RerankProviderConfig,
+    config: &RerankProviderConfig,
 ) -> Result<Arc<dyn Rerank>, LLMError> {
-    default_provider_registry().create_reranker(&config)
+    provider_registry().create_reranker(config)
 }
 
 /// Configuration enum for reranking providers
@@ -82,6 +82,8 @@ pub enum RerankProviderConfig {
 }
 
 impl RerankProviderConfig {
+    /// Return the canonical provider ID.
+    #[must_use]
     pub const fn provider_id(&self) -> ProviderId {
         match self {
             Self::VoyageAI(_) => ProviderId::VoyageAI,

--- a/zqa-rag/src/reranking/common.rs
+++ b/zqa-rag/src/reranking/common.rs
@@ -4,8 +4,6 @@ use std::{pin::Pin, sync::Arc};
 
 use crate::{
     capabilities::RerankerProvider,
-    embedding::{cohere::CohereClient, voyage::VoyageAIClient, zeroentropy::ZeroEntropyClient},
-    http_client::ReqwestClient,
     llm::errors::LLMError,
     providers::{ProviderId, registry::provider_registry},
 };
@@ -27,28 +25,6 @@ pub trait Rerank: Send + Sync {
         items: &'a [&str],
         query: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<usize>, LLMError>> + Send + 'a>>;
-}
-
-/// A factory method for getting a reranking provider.
-///
-/// # Arguments
-///
-/// * `provider` - The name of the provider to get.
-///
-/// # Returns
-///
-/// An `Arc<dyn Rerank>` object, or an `LLMError` if the provider is not supported.
-///
-/// # Errors
-///
-/// Returns an error if the provider name is not recognized.
-#[must_use]
-pub fn get_reranking_provider(provider: RerankerProvider) -> Arc<dyn Rerank> {
-    match provider {
-        RerankerProvider::VoyageAI => Arc::new(VoyageAIClient::<ReqwestClient>::default()),
-        RerankerProvider::Cohere => Arc::new(CohereClient::<ReqwestClient>::default()),
-        RerankerProvider::ZeroEntropy => Arc::new(ZeroEntropyClient::<ReqwestClient>::default()),
-    }
 }
 
 /// Gets a reranking provider with configuration
@@ -94,21 +70,16 @@ impl RerankProviderConfig {
 
     /// Return the provider (enum)
     #[must_use]
+    #[allow(clippy::missing_panics_doc)]
     pub fn provider(&self) -> RerankerProvider {
-        match self {
-            Self::Cohere(_) => RerankerProvider::Cohere,
-            Self::VoyageAI(_) => RerankerProvider::VoyageAI,
-            Self::ZeroEntropy(_) => RerankerProvider::ZeroEntropy,
-        }
+        self.provider_id()
+            .try_into()
+            .expect("Reranking configs always map to valid providers")
     }
 
     #[must_use]
     /// Return the name of the provider for this config.
     pub fn provider_name(&self) -> &str {
-        match self {
-            Self::Cohere(_) => "cohere",
-            Self::VoyageAI(_) => "voyageai",
-            Self::ZeroEntropy(_) => "zeroentropy",
-        }
+        self.provider_id().as_str()
     }
 }

--- a/zqa-rag/src/vector/checkhealth.rs
+++ b/zqa-rag/src/vector/checkhealth.rs
@@ -366,7 +366,12 @@ pub async fn lancedb_health_check(
     // We can't have `result.num_rows` be `None` at this point.
     if let Some(query_limit) = &result.num_rows {
         result.zero_embedding_items = match query_limit {
-            Ok(count) => Some(Ok(get_zero_vectors(&tbl, ProviderId::from(&embedding_provider), *count).await?)),
+            Ok(count) => Some(Ok(get_zero_vectors(
+                &tbl,
+                ProviderId::from(&embedding_provider),
+                *count,
+            )
+            .await?)),
             Err(e) => Some(Err(LanceError::QueryError(e.to_string()))),
         }
     }

--- a/zqa-rag/src/vector/checkhealth.rs
+++ b/zqa-rag/src/vector/checkhealth.rs
@@ -3,6 +3,7 @@
 
 use crate::capabilities::EmbeddingProvider;
 use crate::embedding::common::get_embedding_dims_by_provider;
+use crate::providers::ProviderId;
 
 use super::lance::LanceError;
 use super::lance::{TABLE_NAME, get_db_uri};
@@ -228,9 +229,12 @@ fn calculate_directory_size(path: &std::path::Path) -> Result<u64, std::io::Erro
 ///     * An `InvalidStateError` if the table is in some invalid state
 pub(crate) async fn get_zero_vectors(
     tbl: &Table,
-    embedding_provider: EmbeddingProvider,
+    provider_id: ProviderId,
     query_limit: usize,
 ) -> Result<Vec<RecordBatch>, LanceError> {
+    let embedding_provider = provider_id.try_into().map_err(|message: String| {
+        LanceError::ParameterError(format!("Could not determine embedding provider: {message}"))
+    })?;
     let embedding_size = get_embedding_dims_by_provider(embedding_provider);
 
     let stream = tbl
@@ -362,7 +366,7 @@ pub async fn lancedb_health_check(
     // We can't have `result.num_rows` be `None` at this point.
     if let Some(query_limit) = &result.num_rows {
         result.zero_embedding_items = match query_limit {
-            Ok(count) => Some(Ok(get_zero_vectors(&tbl, embedding_provider, *count).await?)),
+            Ok(count) => Some(Ok(get_zero_vectors(&tbl, ProviderId::from(&embedding_provider), *count).await?)),
             Err(e) => Some(Err(LanceError::QueryError(e.to_string()))),
         }
     }

--- a/zqa-rag/src/vector/lance.rs
+++ b/zqa-rag/src/vector/lance.rs
@@ -2,15 +2,9 @@
 //! LanceDB's features, including connecting, inserting, querying, and deleting. For certain
 //! operations, variants with backup support are provided.
 
-use crate::capabilities::EmbeddingProvider;
-use crate::clients::gemini::GeminiClient;
-use crate::clients::ollama::OllamaClient;
-use crate::clients::openai::OpenAIClient;
-use crate::embedding::cohere::CohereClient;
 use crate::embedding::common::EmbeddingProviderConfig;
-use crate::embedding::voyage::VoyageAIClient;
-use crate::embedding::zeroentropy::ZeroEntropyClient;
-use crate::http_client::ReqwestClient;
+use crate::providers::provider_id::ProviderId;
+use crate::providers::registry::default_provider_registry;
 use crate::vector::backup::with_backup;
 use crate::vector::checkhealth::get_zero_vectors;
 
@@ -99,6 +93,16 @@ impl Display for TableStatistics {
 
         Ok(())
     }
+}
+
+pub trait LanceEmbeddingRegistrar: Send + Sync {
+    fn provider_id(&self) -> ProviderId;
+
+    fn register_with_lancedb(
+        &self,
+        db: &lancedb::Connection,
+        config: &EmbeddingProviderConfig,
+    ) -> Result<(), LanceError>;
 }
 
 /// Checks if an existing LanceDB exists and has a valid table
@@ -205,50 +209,10 @@ pub async fn db_statistics() -> Result<TableStatistics, LanceError> {
 async fn get_db_with_embeddings(
     embedding_config: &EmbeddingProviderConfig,
 ) -> Result<Connection, LanceError> {
-    let db = connect(&get_db_uri())
-        .execute()
-        .await
-        .map_err(|e| LanceError::ConnectionError(e.to_string()))?;
+    let db = connect(&get_db_uri()).execute().await?;
+    let registry = default_provider_registry();
 
-    match embedding_config {
-        EmbeddingProviderConfig::OpenAI(cfg) => {
-            db.embedding_registry().register(
-                EmbeddingProvider::OpenAI.as_str(),
-                Arc::new(OpenAIClient::<ReqwestClient>::with_config(cfg.clone())),
-            )?;
-        }
-        EmbeddingProviderConfig::VoyageAI(cfg) => {
-            db.embedding_registry().register(
-                EmbeddingProvider::VoyageAI.as_str(),
-                Arc::new(VoyageAIClient::<ReqwestClient>::with_config(cfg.clone())),
-            )?;
-        }
-        EmbeddingProviderConfig::Gemini(cfg) => {
-            db.embedding_registry().register(
-                EmbeddingProvider::Gemini.as_str(),
-                Arc::new(GeminiClient::<ReqwestClient>::with_config(cfg.clone())),
-            )?;
-        }
-        EmbeddingProviderConfig::Cohere(cfg) => {
-            db.embedding_registry().register(
-                EmbeddingProvider::Cohere.as_str(),
-                Arc::new(CohereClient::<ReqwestClient>::with_config(cfg.clone())),
-            )?;
-        }
-        EmbeddingProviderConfig::Ollama(cfg) => {
-            db.embedding_registry().register(
-                EmbeddingProvider::Ollama.as_str(),
-                Arc::new(OllamaClient::<ReqwestClient>::with_config(cfg.clone())),
-            )?;
-        }
-        EmbeddingProviderConfig::ZeroEntropy(cfg) => {
-            db.embedding_registry().register(
-                EmbeddingProvider::ZeroEntropy.as_str(),
-                Arc::new(ZeroEntropyClient::<ReqwestClient>::with_config(cfg.clone())),
-            )?;
-        }
-    }
-
+    registry.register_embedding_with_lancedb(&db, embedding_config)?;
     Ok(db)
 }
 

--- a/zqa-rag/src/vector/lance.rs
+++ b/zqa-rag/src/vector/lance.rs
@@ -446,10 +446,10 @@ pub async fn vector_search(
     let start_time = Instant::now();
     let embedding = db
         .embedding_registry()
-        .get(embedding_config.provider_name())
+        .get(embedding_config.provider_id().as_str())
         .ok_or(LanceError::InvalidStateError(format!(
             "{} is not in the database embedding registry",
-            embedding_config.provider_name()
+            embedding_config.provider_id().as_str()
         )))?;
 
     let query_vec = embedding.compute_query_embeddings(Arc::new(StringArray::from(vec![query])))?;

--- a/zqa-rag/src/vector/lance.rs
+++ b/zqa-rag/src/vector/lance.rs
@@ -283,7 +283,7 @@ pub async fn get_zero_vector_records(
     })?;
 
     // Get all records with zero embeddings
-    let zero_batches = get_zero_vectors(&table, embedding_config.provider(), 10000).await?;
+    let zero_batches = get_zero_vectors(&table, embedding_config.provider_id(), 10000).await?;
     Ok(zero_batches)
 }
 
@@ -623,7 +623,7 @@ pub async fn insert_records(
     } else {
         let embedding_params = EmbeddingDefinition::new(
             source_col,
-            embedding_config.provider_name(),
+            embedding_config.provider_id().as_str(),
             Some("embeddings"),
         );
 

--- a/zqa-rag/src/vector/lance.rs
+++ b/zqa-rag/src/vector/lance.rs
@@ -4,7 +4,7 @@
 
 use crate::embedding::common::EmbeddingProviderConfig;
 use crate::providers::provider_id::ProviderId;
-use crate::providers::registry::default_provider_registry;
+use crate::providers::registry::provider_registry;
 use crate::vector::backup::with_backup;
 use crate::vector::checkhealth::get_zero_vectors;
 
@@ -95,9 +95,16 @@ impl Display for TableStatistics {
     }
 }
 
+/// Registration methods for embedding providers to interface with LanceDB
 pub trait LanceEmbeddingRegistrar: Send + Sync {
+    /// Get the provider ID for this object
     fn provider_id(&self) -> ProviderId;
 
+    /// Register this provider with LanceDB
+    ///
+    /// # Errors
+    ///
+    /// Return a [`LanceError`] if registration fails.
     fn register_with_lancedb(
         &self,
         db: &lancedb::Connection,
@@ -210,7 +217,7 @@ async fn get_db_with_embeddings(
     embedding_config: &EmbeddingProviderConfig,
 ) -> Result<Connection, LanceError> {
     let db = connect(&get_db_uri()).execute().await?;
-    let registry = default_provider_registry();
+    let registry = provider_registry();
 
     registry.register_embedding_with_lancedb(&db, embedding_config)?;
     Ok(db)

--- a/zqa/src/cli/app.rs
+++ b/zqa/src/cli/app.rs
@@ -652,7 +652,7 @@ async fn search_for_papers<O: Write, E: Write>(
             .ok_or(CLIError::ConfigError(
                 "Could not get embedding config".into(),
             ))?,
-        ctx.config.reranker_provider,
+        ctx.config.get_reranker_config().as_ref(),
     )
     .await?;
     let _ = get_authors(&mut search_results);
@@ -705,7 +705,7 @@ async fn run_query<O: Write, E: Write>(
         .ok_or(CLIError::ConfigError(
             "Could not get embedding config".into(),
         ))?;
-    let reranker_provider = ctx.config.reranker_provider;
+    let reranker_config = ctx.config.get_reranker_config();
 
     // Spawn a background title generation task from the query alone, in parallel with summarization.
     // Only generate a title if we don't already have one (i.e., first query in the conversation).
@@ -739,7 +739,7 @@ async fn run_query<O: Write, E: Write>(
     let mut total_input_tokens: u32 = 0;
     let mut total_output_tokens: u32 = 0;
 
-    let retrieval_tool = RetrievalTool::new(embedding_config, reranker_provider);
+    let retrieval_tool = RetrievalTool::new(embedding_config, reranker_config);
     let summarization_tool = SummarizationTool::new(llm_client.clone());
     let summarization_tool_clone = summarization_tool.clone();
     let mut tools: Vec<Box<dyn Tool>> =
@@ -1358,13 +1358,13 @@ pub(crate) mod tests {
     use temp_env;
     use zqa_macros::{test_contains, test_eq, test_ok};
     use zqa_macros_proc::retry;
-    use zqa_rag::capabilities::RerankerProvider;
     use zqa_rag::constants::{
         DEFAULT_VOYAGE_EMBEDDING_DIM, DEFAULT_VOYAGE_EMBEDDING_MODEL, DEFAULT_VOYAGE_RERANK_MODEL,
     };
     use zqa_rag::embedding::common::EmbeddingProviderConfig;
     use zqa_rag::llm::base::{ASSISTANT_ROLE, ChatHistoryContent, ChatHistoryItem, USER_ROLE};
     use zqa_rag::llm::tools::Tool;
+    use zqa_rag::reranking::common::RerankProviderConfig;
 
     use crate::common::Context;
 
@@ -1403,16 +1403,18 @@ pub(crate) mod tests {
     }
 
     fn make_retrieval_tool(_schema_key: &str) -> RetrievalTool {
+        let config = zqa_rag::config::VoyageAIConfig {
+            api_key: String::new(),
+            embedding_model: DEFAULT_VOYAGE_EMBEDDING_MODEL.into(),
+            embedding_dims: DEFAULT_VOYAGE_EMBEDDING_DIM as usize,
+            reranker: DEFAULT_VOYAGE_RERANK_MODEL.into(),
+        };
+
         // Build a minimal tool; the embedding config is only used in `call`, not in the metadata
         // methods, so we use a dummy VoyageAI config here.
         RetrievalTool::new(
-            EmbeddingProviderConfig::VoyageAI(zqa_rag::config::VoyageAIConfig {
-                api_key: String::new(),
-                embedding_model: DEFAULT_VOYAGE_EMBEDDING_MODEL.into(),
-                embedding_dims: DEFAULT_VOYAGE_EMBEDDING_DIM as usize,
-                reranker: DEFAULT_VOYAGE_RERANK_MODEL.into(),
-            }),
-            Some(RerankerProvider::VoyageAI),
+            EmbeddingProviderConfig::VoyageAI(config.clone()),
+            Some(RerankProviderConfig::VoyageAI(config)),
         )
     }
 

--- a/zqa/src/cli/app.rs
+++ b/zqa/src/cli/app.rs
@@ -19,6 +19,7 @@ use zqa_rag::llm::base::{
 use zqa_rag::llm::factory::get_client_with_config;
 use zqa_rag::llm::tools::{CallbackFn, Tool};
 use zqa_rag::pricing::get_model_pricing;
+use zqa_rag::providers::registry::provider_registry;
 use zqa_rag::vector::checkhealth::lancedb_health_check;
 use zqa_rag::vector::doctor::doctor as rag_doctor;
 use zqa_rag::vector::lance::{
@@ -277,7 +278,7 @@ fn get_user_document_tools<O: Write, E: Write>(
     let client = ctx
         .config
         .get_generation_config()
-        .map(get_client_with_config)
+        .map(|c| provider_registry().create_llm(&c))
         .transpose()?;
 
     Ok(
@@ -687,14 +688,13 @@ async fn run_query<O: Write, E: Write>(
 ) -> Result<(), CLIError> {
     let model_provider = ctx.config.model_provider;
 
-    // Create LLM client with config
     let llm_client = ctx
         .config
         .get_generation_config()
-        .map(get_client_with_config)
+        .map(|c| provider_registry().create_llm(&c))
         .transpose()?
         .ok_or(CLIError::ConfigError(
-            "Could not get generation config".into(),
+            "Failed to get LLM generation config in `run_query`".into(),
         ))?;
 
     let generation_model_name = ctx.config.get_generation_model_name();
@@ -712,7 +712,7 @@ async fn run_query<O: Write, E: Write>(
     let title_slot = Arc::clone(&ctx.state.title);
     if title_slot.lock()?.is_none()
         && let Some(small_config) = ctx.config.get_small_model_config()
-        && let Ok(small_client) = get_client_with_config(small_config)
+        && let Ok(small_client) = get_client_with_config(&small_config)
     {
         let prompt = get_title_prompt(&query);
         tokio::spawn(async move {

--- a/zqa/src/tools/documents.rs
+++ b/zqa/src/tools/documents.rs
@@ -368,7 +368,7 @@ async fn embedding_retrieval(
         .map(std::string::String::as_str)
         .collect();
 
-    let provider = get_embedding_provider_with_config(embedding_config.clone())?;
+    let provider = get_embedding_provider_with_config(embedding_config)?;
     let chunk_embeddings = get_embeddings(&chunk_text_refs, &provider)?;
 
     let query_embeddings = get_embeddings(&[query], &provider)?;
@@ -994,7 +994,7 @@ mod tests {
             .expect("VOYAGE_AI_API_KEY must be set for this test");
 
         let client =
-            get_client_with_config(LLMClientConfig::OpenAI(zqa_rag::config::OpenAIConfig {
+            get_client_with_config(&LLMClientConfig::OpenAI(zqa_rag::config::OpenAIConfig {
                 api_key: api_key.clone(),
                 model: DEFAULT_OPENAI_MODEL_SMALL.to_string(),
                 max_tokens: DEFAULT_OPENAI_MAX_TOKENS,

--- a/zqa/src/tools/documents.rs
+++ b/zqa/src/tools/documents.rs
@@ -22,7 +22,7 @@ use zqa_pdftools::{
 use zqa_rag::{
     embedding::common::EmbeddingProviderConfig,
     llm::{base::ApiClient, errors::LLMError, factory::LLMClient, tools::Tool},
-    reranking::common::{RerankProviderConfig, get_reranking_provider},
+    reranking::common::{RerankProviderConfig, get_reranking_provider_with_config},
 };
 
 use crate::common::UserDocument;
@@ -424,8 +424,8 @@ async fn embedding_retrieval(
             .collect());
     };
 
-    let reranker = get_reranking_provider(reranker_config.provider());
-    let reranked_idx = reranker.rerank(&kept_chunks, query).await?;
+    let reranker = get_reranking_provider_with_config(reranker_config)?;
+    let reranked_idx: Vec<usize> = reranker.rerank(&kept_chunks, query).await?;
 
     let reranked_chunks: Vec<String> = reranked_idx
         .into_iter()

--- a/zqa/src/tools/retrieval.rs
+++ b/zqa/src/tools/retrieval.rs
@@ -76,7 +76,8 @@ impl Tool for RetrievalTool {
     fn call(
         &self,
         args: serde_json::Value,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<serde_json::Value, String>> + Send + '_>> {
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<serde_json::Value, String>> + Send + '_>>
+    {
         let start = Instant::now();
         let embedding_config = self.embedding_config.clone();
         let reranker_config = self.reranker_config.clone();
@@ -84,13 +85,10 @@ impl Tool for RetrievalTool {
         Box::pin(async move {
             let input: RetrievalToolInput =
                 serde_json::from_value(args).map_err(|e| format!("Invalid arguments: {e}"))?;
-            let mut results = vector_search(
-                input.query,
-                &embedding_config,
-                reranker_config.as_ref(),
-            )
-            .await
-            .map_err(|e| format!("Search failed: {e}"))?;
+            let mut results =
+                vector_search(input.query, &embedding_config, reranker_config.as_ref())
+                    .await
+                    .map_err(|e| format!("Search failed: {e}"))?;
 
             get_authors(&mut results).map_err(|e| format!("Failed to get authors: {e}"))?;
             log::info!(

--- a/zqa/src/tools/retrieval.rs
+++ b/zqa/src/tools/retrieval.rs
@@ -4,7 +4,8 @@ use schemars::{JsonSchema, schema_for};
 use serde::Deserialize;
 use serde_json::json;
 use zqa_rag::{
-    capabilities::RerankerProvider, embedding::common::EmbeddingProviderConfig, llm::tools::Tool,
+    embedding::common::EmbeddingProviderConfig, llm::tools::Tool,
+    reranking::common::RerankProviderConfig,
 };
 
 use crate::utils::{
@@ -22,7 +23,7 @@ pub(crate) struct RetrievalTool {
     /// used when initially creating the database.
     pub(crate) embedding_config: EmbeddingProviderConfig,
     /// The reranker provider to use.
-    pub(crate) reranker_provider: Option<RerankerProvider>,
+    pub(crate) reranker_config: Option<RerankProviderConfig>,
 }
 
 impl RetrievalTool {
@@ -30,11 +31,11 @@ impl RetrievalTool {
     /// reranker provider, and a schema key.
     pub(crate) fn new(
         embedding_config: EmbeddingProviderConfig,
-        reranker_provider: Option<RerankerProvider>,
+        reranker_provider: Option<RerankProviderConfig>,
     ) -> Self {
         Self {
             embedding_config,
-            reranker_provider,
+            reranker_config: reranker_provider,
         }
     }
 }
@@ -75,16 +76,21 @@ impl Tool for RetrievalTool {
     fn call(
         &self,
         args: serde_json::Value,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<serde_json::Value, String>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<serde_json::Value, String>> + Send + '_>> {
         let start = Instant::now();
         let embedding_config = self.embedding_config.clone();
-        let reranker_provider = self.reranker_provider;
+        let reranker_config = self.reranker_config.clone();
+
         Box::pin(async move {
             let input: RetrievalToolInput =
                 serde_json::from_value(args).map_err(|e| format!("Invalid arguments: {e}"))?;
-            let mut results = vector_search(input.query, &embedding_config, reranker_provider)
-                .await
-                .map_err(|e| format!("Search failed: {e}"))?;
+            let mut results = vector_search(
+                input.query,
+                &embedding_config,
+                reranker_config.as_ref(),
+            )
+            .await
+            .map_err(|e| format!("Search failed: {e}"))?;
 
             get_authors(&mut results).map_err(|e| format!("Failed to get authors: {e}"))?;
             log::info!(
@@ -125,16 +131,18 @@ mod tests {
     use zqa_rag::embedding::common::EmbeddingProviderConfig;
 
     fn make_tool() -> RetrievalTool {
+        let config = zqa_rag::config::VoyageAIConfig {
+            api_key: String::new(),
+            embedding_model: DEFAULT_VOYAGE_EMBEDDING_MODEL.into(),
+            embedding_dims: DEFAULT_VOYAGE_EMBEDDING_DIM as usize,
+            reranker: DEFAULT_VOYAGE_RERANK_MODEL.into(),
+        };
+
         // Build a minimal tool; the embedding config is only used in `call`, not in the metadata
         // methods, so we use a dummy VoyageAI config here.
         RetrievalTool::new(
-            EmbeddingProviderConfig::VoyageAI(zqa_rag::config::VoyageAIConfig {
-                api_key: String::new(),
-                embedding_model: DEFAULT_VOYAGE_EMBEDDING_MODEL.into(),
-                embedding_dims: DEFAULT_VOYAGE_EMBEDDING_DIM as usize,
-                reranker: DEFAULT_VOYAGE_RERANK_MODEL.into(),
-            }),
-            Some(RerankerProvider::VoyageAI),
+            EmbeddingProviderConfig::VoyageAI(config.clone()),
+            Some(RerankProviderConfig::VoyageAI(config)),
         )
     }
 

--- a/zqa/src/tools/summarization.rs
+++ b/zqa/src/tools/summarization.rs
@@ -173,7 +173,7 @@ mod tests {
     };
 
     fn make_tool() -> SummarizationTool {
-        let client = get_client_with_config(LLMClientConfig::Anthropic(AnthropicConfig {
+        let client = get_client_with_config(&LLMClientConfig::Anthropic(AnthropicConfig {
             api_key: env::var("ANTHROPIC_API_KEY").unwrap(),
             model: DEFAULT_ANTHROPIC_MODEL_SMALL.into(),
             max_tokens: 8192,

--- a/zqa/src/utils/arrow.rs
+++ b/zqa/src/utils/arrow.rs
@@ -7,12 +7,12 @@ use crate::{
     utils::library::{ZoteroItem, ZoteroItemSet},
 };
 use zqa_rag::{
-    capabilities::{EmbeddingProvider, RerankerProvider},
+    capabilities::EmbeddingProvider,
     embedding::common::{
         EmbeddingProviderConfig, get_embedding_dims_by_provider, get_embedding_provider_with_config,
     },
     llm::errors::LLMError,
-    reranking::common::get_reranking_provider,
+    reranking::common::{RerankProviderConfig, get_reranking_provider_with_config},
     vector::lance::{LanceError, lancedb_exists, vector_search as rag_vector_search},
 };
 
@@ -281,7 +281,7 @@ pub async fn full_library_to_arrow(
 /// * `query` - The query to search the `LanceDB` table for.
 /// * `embedding_config` - The embedding provider configuration. Note that this must be the same
 ///   embedding provider used when initially creating the database.
-/// * `reranker` - The reranker provider to use.
+/// * `reranker_config` - The reranker provider to use.
 ///
 /// # Returns
 ///
@@ -296,7 +296,7 @@ pub async fn full_library_to_arrow(
 pub async fn vector_search(
     query: String,
     embedding_config: &EmbeddingProviderConfig,
-    reranker: Option<RerankerProvider>,
+    reranker_config: Option<&RerankProviderConfig>,
 ) -> Result<Vec<ZoteroItem>, ArrowError> {
     let batches = rag_vector_search(query.clone(), embedding_config, 10).await?;
 
@@ -312,11 +312,11 @@ pub async fn vector_search(
         return Ok(Vec::new());
     }
 
-    let Some(reranker) = reranker else {
+    let Some(reranker) = reranker_config else {
         return Ok(filtered_items);
     };
 
-    let rerank_provider = get_reranking_provider(reranker);
+    let rerank_provider = get_reranking_provider_with_config(reranker)?;
     let item_strings = filtered_items
         .iter()
         .map(|f| f.text.as_str())

--- a/zqa/src/utils/arrow.rs
+++ b/zqa/src/utils/arrow.rs
@@ -196,7 +196,7 @@ pub async fn library_to_arrow(
     ];
 
     if lancedb_exists().await {
-        let embedding_provider = get_embedding_provider_with_config(embedding_config)?;
+        let embedding_provider = get_embedding_provider_with_config(&embedding_config)?;
         let query_vec = embedding_provider.compute_source_embeddings(Arc::new(pdf_texts))?;
         let query_vec = query_vec.as_fixed_size_list();
 

--- a/zqa/tests/extraction_prompt.rs
+++ b/zqa/tests/extraction_prompt.rs
@@ -101,7 +101,7 @@ async fn test_extraction_prompt_openai() {
         embedding_dims: None,
     };
 
-    let client = get_client_with_config(LLMClientConfig::OpenAI(config.into()))
+    let client = get_client_with_config(&LLMClientConfig::OpenAI(config.into()))
         .expect("Failed to create OpenAI client");
 
     run_extraction_test(client, "OpenAI").await;
@@ -129,7 +129,7 @@ async fn test_extraction_prompt_anthropic() {
         max_tokens: 8192,
     };
 
-    let client = get_client_with_config(LLMClientConfig::Anthropic(config.into()))
+    let client = get_client_with_config(&LLMClientConfig::Anthropic(config.into()))
         .expect("Failed to create Anthropic client");
 
     run_extraction_test(client, "Anthropic").await;
@@ -159,7 +159,7 @@ async fn test_extraction_prompt_gemini() {
         embedding_dims: None,
     };
 
-    let client = get_client_with_config(LLMClientConfig::Gemini(config.into()))
+    let client = get_client_with_config(&LLMClientConfig::Gemini(config.into()))
         .expect("Failed to create Gemini client");
 
     run_extraction_test(client, "Gemini").await;


### PR DESCRIPTION
This PR adds a registry system for providers with the goal of having one canonical set of providers, and a single way to create and use them.



PR reviewers: you should also assess whether this PR's design overall is good and necessary, and whether this improves the ergonomics of using the RAG crate.