### PR TITLE
refactor: create `VectorBackend` trait and implement for LanceDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6742,6 +6742,7 @@ version = "0.1.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
+ "async-trait",
  "bytes",
  "dotenv",
  "futures",

--- a/zqa-rag/Cargo.toml
+++ b/zqa-rag/Cargo.toml
@@ -28,6 +28,7 @@ tempfile = "3.0"
 thiserror = "1.0"
 tokio = "1.41.0"
 zqa-pdftools = { workspace = true }
+async-trait = "0.1.89"
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/zqa-rag/src/vector/backends/backend.rs
+++ b/zqa-rag/src/vector/backends/backend.rs
@@ -1,6 +1,6 @@
 //! Traits for vector database backends.
 
-use std::fmt::Display;
+use async_trait::async_trait;
 
 use crate::providers::ProviderId;
 
@@ -18,16 +18,17 @@ pub trait VectorBackendRegistrar: VectorBackend + Send + Sync {
 }
 
 /// A vector database backend.
-pub trait VectorBackend {
+#[async_trait]
+pub trait VectorBackend: Send + Sync {
     /// The record type for the backend.
-    type Record;
+    type Record: Send;
     /// The error type for the backend.
-    type Error;
+    type Error: Send;
     /// The configuration type for the backend. A backend may not have a config at all, in which
     /// case the [`Config`] type should be `()`.
-    type Config;
+    type Config: Send + Sync;
     /// The connection type for the backend.
-    type Connection;
+    type Connection: Send + Sync;
 
     /// Returns the *base* path for the DB. This can be path on the local disk for LanceDB's
     /// database, a connection URL, etc.
@@ -36,7 +37,7 @@ pub trait VectorBackend {
 
     /// Whether the path specified by [`get_db_path`] exists.
     #[must_use]
-    fn db_exists(&self) -> impl Future<Output = bool> + Send + '_;
+    async fn db_exists(&self) -> bool;
 
     /// Create indices for the database. The details of the type of index are left to the trait
     /// implementer. If the index exists, then it is updated instead.
@@ -45,18 +46,14 @@ pub trait VectorBackend {
     ///
     /// * `text_col` - The name of the text column to index.
     /// * `embedding_col` - The name of the embedding column to index.
-    fn create_or_update_indices<'a>(
-        &'a self,
-        text_col: &'a str,
-        embedding_col: &'a str,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
+    async fn create_or_update_indices(
+        &self,
+        text_col: &str,
+        embedding_col: &str,
+    ) -> Result<(), Self::Error>;
 
-    /// Connect to the database using the given configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - The configuration to use for connecting to the database.
-    fn connect(&self) -> impl Future<Output = Result<Self::Connection, Self::Error>> + Send + '_;
+    /// Connect to the database.
+    async fn connect(&self) -> Result<Self::Connection, Self::Error>;
 
     /// Delete rows from the database based on the given column and keys.
     ///
@@ -65,11 +62,7 @@ pub trait VectorBackend {
     /// * `col` - The name of the column to delete rows from.
     /// * `keys` - The keys of the rows to delete. The values must correspond to values in the
     ///   `col` column.
-    fn delete_rows<'a>(
-        &'a self,
-        col: &'a str,
-        keys: &'a [impl AsRef<str> + Send + Sync],
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
+    async fn delete_rows(&self, col: &str, keys: &[String]) -> Result<(), Self::Error>;
 
     /// Deduplicate rows in the database based on the given column and key.
     ///
@@ -81,11 +74,7 @@ pub trait VectorBackend {
     /// # Returns
     ///
     /// The number of rows deleted.
-    fn dedup_rows<'a>(
-        &'a self,
-        by: &'a str,
-        key: &'a str,
-    ) -> impl Future<Output = Result<usize, Self::Error>> + Send + 'a;
+    async fn dedup_rows(&self, by: &str, key: &str) -> Result<usize, Self::Error>;
 
     /// Get all items from the database.
     ///
@@ -96,10 +85,7 @@ pub trait VectorBackend {
     /// # Returns
     ///
     /// A vector of all items in the database.
-    fn get_items<'a>(
-        &'a self,
-        columns: &'a [impl AsRef<str> + Send + Sync + Display],
-    ) -> impl Future<Output = Result<Vec<Self::Record>, Self::Error>> + Send + 'a;
+    async fn get_items(&self, columns: &[String]) -> Result<Vec<Self::Record>, Self::Error>;
 
     /// Search for items in the database using a vector query.
     ///
@@ -111,11 +97,11 @@ pub trait VectorBackend {
     /// # Returns
     ///
     /// A vector of items that match the query.
-    fn vector_search(
+    async fn vector_search(
         &self,
         query: String,
         limit: usize,
-    ) -> impl Future<Output = Result<Vec<Self::Record>, Self::Error>> + Send + '_;
+    ) -> Result<Vec<Self::Record>, Self::Error>;
 
     /// Search for an item in the database by its key.
     ///
@@ -127,11 +113,11 @@ pub trait VectorBackend {
     /// # Returns
     ///
     /// The item that matches the key, if one exists.
-    fn search_by_key<'a>(
-        &'a self,
-        key_col: &'a str,
-        key: &'a str,
-    ) -> impl Future<Output = Result<Option<Self::Record>, Self::Error>> + Send + 'a;
+    async fn search_by_key(
+        &self,
+        key_col: &str,
+        key: &str,
+    ) -> Result<Option<Self::Record>, Self::Error>;
 
     /// Search for items in the database by a column value.
     ///
@@ -143,11 +129,11 @@ pub trait VectorBackend {
     /// # Returns
     ///
     /// A vector of items that match the column value.
-    fn search_by_column<'a>(
-        &'a self,
-        col: &'a str,
-        values: &'a [impl AsRef<str> + Send + Sync + Display],
-    ) -> impl Future<Output = Result<Vec<Self::Record>, Self::Error>> + Send + 'a;
+    async fn search_by_column(
+        &self,
+        col: &str,
+        values: &[String],
+    ) -> Result<Vec<Self::Record>, Self::Error>;
 
     /// Insert items into the database.
     ///
@@ -156,15 +142,13 @@ pub trait VectorBackend {
     /// * `items` - The items to insert.
     /// * `merge_on` - `None` if you want to create or overwrite the current database; otherwise, a
     ///   reference to an array of keys to merge on.
-    /// * `source_col` - The name of the column in `items` that contains the source document text.
     ///
     /// # Returns
     ///
     /// `Ok(())` if the items were inserted successfully, or an error otherwise.
-    fn insert_items<'a>(
-        &'a self,
+    async fn insert_items(
+        &self,
         items: Vec<Self::Record>,
-        merge_on: Option<&'a [&str]>,
-        source_col: &'a str,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
+        merge_on: Option<&[&str]>,
+    ) -> Result<(), Self::Error>;
 }

--- a/zqa-rag/src/vector/backends/backend.rs
+++ b/zqa-rag/src/vector/backends/backend.rs
@@ -1,0 +1,173 @@
+//! Traits for vector database backends.
+
+use std::fmt::Display;
+
+use crate::providers::ProviderId;
+
+/// Registration methods for embedding providers to interface with the backend.
+pub trait VectorBackendRegistrar: VectorBackend + Send + Sync {
+    /// Get the provider ID for this object
+    fn provider_id(&self) -> ProviderId;
+
+    /// Register this provider with the vector backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the registration fails.
+    fn register(&self, db: &lancedb::Connection, config: &Self::Config) -> Result<(), Self::Error>;
+}
+
+/// A vector database backend.
+pub trait VectorBackend {
+    /// The record type for the backend.
+    type Record;
+    /// The backend's "native" type for multiple embeddings. This is the return type when embeddings
+    /// are generated.
+    type EmbeddingColumn;
+    /// The error type for the backend.
+    type Error;
+    /// The configuration type for the backend. A backend may not have a config at all, in which
+    /// case the [`Config`] type should be `()`.
+    type Config;
+    /// The connection type for the backend.
+    type Connection;
+
+    /// Returns the *base* path for the DB. This can be path on the local disk for LanceDB's
+    /// database, a connection URL, etc.
+    #[must_use]
+    fn get_db_path() -> String;
+
+    /// Whether the path specified by [`get_db_path`] exists.
+    #[must_use]
+    fn db_exists(&self) -> impl Future<Output = bool> + Send + '_;
+
+    /// Create indices for the database. The details of the type of index are left to the trait
+    /// implementer. If the index exists, then it is updated instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `text_col` - The name of the text column to index.
+    /// * `embedding_col` - The name of the embedding column to index.
+    fn create_or_update_indices<'a>(
+        text_col: &'a str,
+        embedding_col: &'a str,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
+
+    /// Connect to the database using the given configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The configuration to use for connecting to the database.
+    fn connect(&self) -> impl Future<Output = Result<Self::Connection, Self::Error>> + Send + '_;
+
+    /// Delete rows from the database based on the given column and keys.
+    ///
+    /// # Arguments
+    ///
+    /// * `col` - The name of the column to delete rows from.
+    /// * `keys` - The keys of the rows to delete. The values must correspond to values in the
+    ///   `col` column.
+    /// * `config` - The configuration to use for connecting to the database.
+    fn delete_rows<'a>(
+        &'a self,
+        col: &'a str,
+        keys: &'a [impl AsRef<str> + Send + Sync],
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
+
+    /// Deduplicate rows in the database based on the given column and key.
+    ///
+    /// # Arguments
+    ///
+    /// * `by` - The column to deduplicate rows by.
+    /// * `key` - The column to use as the key for deletion.
+    ///
+    /// # Returns
+    ///
+    /// The number of rows deleted.
+    fn dedup_rows<'a>(
+        &'a self,
+        by: &'a str,
+        key: &'a str,
+    ) -> impl Future<Output = Result<usize, Self::Error>> + Send + 'a;
+
+    /// Get all items from the database.
+    ///
+    /// # Arguments
+    ///
+    /// * `columns` - The columns to return.
+    ///
+    /// # Returns
+    ///
+    /// A vector of all items in the database.
+    fn get_items<'a>(
+        &'a self,
+        columns: &'a [impl AsRef<str> + Send + Sync + Display],
+    ) -> impl Future<Output = Result<Vec<Self::Record>, Self::Error>> + Send + 'a;
+
+    /// Search for items in the database using a vector query.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query to search for.
+    /// * `limit` - The maximum number of results to return.
+    ///
+    /// # Returns
+    ///
+    /// A vector of items that match the query.
+    fn vector_search(
+        &self,
+        query: String,
+        limit: usize,
+    ) -> impl Future<Output = Result<Vec<Self::Record>, Self::Error>> + Send + '_;
+
+    /// Search for an item in the database by its key.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_col` - The column to use as the key.
+    /// * `key` - The key to search for.
+    ///
+    /// # Returns
+    ///
+    /// The item that matches the key, if one exists.
+    fn search_by_key<'a>(
+        &'a self,
+        key_col: &'a str,
+        key: &'a str,
+    ) -> impl Future<Output = Result<Self::Record, Self::Error>> + Send + 'a;
+
+    /// Search for items in the database by a column value.
+    ///
+    /// # Arguments
+    ///
+    /// * `col` - The column to search by.
+    /// * `values` - The values to search for.
+    ///
+    /// # Returns
+    ///
+    /// A vector of items that match the column value.
+    fn search_by_column<'a>(
+        &'a self,
+        col: &'a str,
+        values: &'a [impl AsRef<str> + Send + Sync + Display],
+    ) -> impl Future<Output = Result<Vec<Self::Record>, Self::Error>> + Send + 'a;
+
+    /// Insert items into the database.
+    ///
+    /// # Arguments
+    ///
+    /// * `items` - The items to insert.
+    /// * `merge_on` - `None` if you want to create or overwrite the current database; otherwise, a
+    ///   reference to an array of keys to merge on.
+    /// * `source_col` - The name of the column in `items` that contains the source document text.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the items were inserted successfully, or an error otherwise.
+    fn insert_items<'a>(
+        &'a self,
+        items: Vec<Self::Record>,
+        merge_on: Option<&'a [&str]>,
+        source_col: &'a str,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
+}

--- a/zqa-rag/src/vector/backends/backend.rs
+++ b/zqa-rag/src/vector/backends/backend.rs
@@ -65,7 +65,6 @@ pub trait VectorBackend {
     /// * `col` - The name of the column to delete rows from.
     /// * `keys` - The keys of the rows to delete. The values must correspond to values in the
     ///   `col` column.
-    /// * `config` - The configuration to use for connecting to the database.
     fn delete_rows<'a>(
         &'a self,
         col: &'a str,

--- a/zqa-rag/src/vector/backends/backend.rs
+++ b/zqa-rag/src/vector/backends/backend.rs
@@ -14,16 +14,13 @@ pub trait VectorBackendRegistrar: VectorBackend + Send + Sync {
     /// # Errors
     ///
     /// Returns an error if the registration fails.
-    fn register(&self, db: &lancedb::Connection, config: &Self::Config) -> Result<(), Self::Error>;
+    fn register(&self, db: &Self::Connection, config: &Self::Config) -> Result<(), Self::Error>;
 }
 
 /// A vector database backend.
 pub trait VectorBackend {
     /// The record type for the backend.
     type Record;
-    /// The backend's "native" type for multiple embeddings. This is the return type when embeddings
-    /// are generated.
-    type EmbeddingColumn;
     /// The error type for the backend.
     type Error;
     /// The configuration type for the backend. A backend may not have a config at all, in which
@@ -35,7 +32,7 @@ pub trait VectorBackend {
     /// Returns the *base* path for the DB. This can be path on the local disk for LanceDB's
     /// database, a connection URL, etc.
     #[must_use]
-    fn get_db_path() -> String;
+    fn get_db_path(&self) -> String;
 
     /// Whether the path specified by [`get_db_path`] exists.
     #[must_use]
@@ -49,6 +46,7 @@ pub trait VectorBackend {
     /// * `text_col` - The name of the text column to index.
     /// * `embedding_col` - The name of the embedding column to index.
     fn create_or_update_indices<'a>(
+        &'a self,
         text_col: &'a str,
         embedding_col: &'a str,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'a;
@@ -134,7 +132,7 @@ pub trait VectorBackend {
         &'a self,
         key_col: &'a str,
         key: &'a str,
-    ) -> impl Future<Output = Result<Self::Record, Self::Error>> + Send + 'a;
+    ) -> impl Future<Output = Result<Option<Self::Record>, Self::Error>> + Send + 'a;
 
     /// Search for items in the database by a column value.
     ///

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -212,7 +212,7 @@ impl VectorBackend for LanceBackend {
             return Ok(());
         }
 
-        let col = self.schema.field_with_name(col).map_err(|_| {
+        self.schema.field_with_name(col).map_err(|_| {
             LanceError::ParameterError(format!("Column {col} does not exist in the schema"))
         })?;
 
@@ -450,8 +450,11 @@ impl VectorBackend for LanceBackend {
         key_col: &str,
         key: &str,
     ) -> Result<Option<Self::Record>, Self::Error> {
-        let db = self.connect().await?;
+        self.schema.field_with_name(key_col).map_err(|_| {
+            LanceError::ParameterError(format!("Column {key_col} does not exist in the schema"))
+        })?;
 
+        let db = self.connect().await?;
         let tbl = db
             .open_table(LANCE_TABLE_NAME)
             .execute()
@@ -502,6 +505,10 @@ impl VectorBackend for LanceBackend {
         if values.is_empty() {
             return Ok(Vec::new());
         }
+
+        self.schema.field_with_name(col).map_err(|_| {
+            LanceError::ParameterError(format!("Column {col} does not exist in the schema"))
+        })?;
 
         let db = self.connect().await?;
         let tbl = db

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -1,19 +1,18 @@
 //! LanceDB vector backend implementation.
 
-use arrow_array::cast::AsArray;
-use arrow_array::types::Float32Type;
-use futures::TryStreamExt;
-use lancedb::database::CreateTableMode;
-use lancedb::embeddings::EmbeddingDefinition;
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
+use arrow_array::cast::AsArray;
+use arrow_array::types::Float32Type;
 use arrow_array::{RecordBatch, RecordBatchIterator, StringArray};
-
 use arrow_schema::{ArrowError, Schema};
+use futures::TryStreamExt;
+use lancedb::database::CreateTableMode;
+use lancedb::embeddings::EmbeddingDefinition;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::{Connection, Error as LanceDbError, connect, index::scalar::FtsIndexBuilder};
 use thiserror::Error;
@@ -23,7 +22,7 @@ use crate::{
     vector::backends::backend::VectorBackend,
 };
 
-// NOTE: Maintainers: ensure that `DB_URI` begins with `TABLE_NAME`
+// NOTE: Maintainers: ensure that `LANCEDB_URI` begins with `LANCE_TABLE_NAME`
 
 /// The URI for the LanceDB table. This is the default location for the table, and for now cannot
 /// be changed.
@@ -65,7 +64,7 @@ pub enum LanceError {
 pub struct LanceBackend {
     /// Configuration for the LanceDB embedding provider.
     config: EmbeddingProviderConfig,
-    /// Arrow schema for the LanceDB table.:w
+    /// Arrow schema for the LanceDB table.
     schema: Arc<Schema>,
 }
 
@@ -93,19 +92,18 @@ impl LanceBackend {
 
 impl VectorBackend for LanceBackend {
     type Record = RecordBatch;
-    type EmbeddingColumn = Vec<RecordBatch>;
     type Error = LanceError;
     type Config = EmbeddingProviderConfig;
     type Connection = Connection;
 
     /// Returns the database URI, allowing override via `LANCEDB_URI` environment variable.
-    fn get_db_path() -> String {
+    fn get_db_path(&self) -> String {
         std::env::var("LANCEDB_URI").unwrap_or_else(|_| LANCEDB_URI.to_string())
     }
 
     /// Checks if an existing LanceDB exists and has a valid table
     async fn db_exists(&self) -> bool {
-        let uri = LanceBackend::get_db_path();
+        let uri = self.get_db_path();
         if !PathBuf::from(&uri).exists() {
             return false;
         }
@@ -132,10 +130,11 @@ impl VectorBackend for LanceBackend {
     ///
     /// Returns an error if the database connection fails, table operations fail, or index creation fails.
     async fn create_or_update_indices<'a>(
+        &'a self,
         text_col: &'a str,
         embedding_col: &'a str,
     ) -> Result<(), Self::Error> {
-        let db = connect(&LanceBackend::get_db_path())
+        let db = connect(&self.get_db_path())
             .execute()
             .await
             .map_err(|e| LanceError::ConnectionError(e.to_string()))?;
@@ -174,7 +173,7 @@ impl VectorBackend for LanceBackend {
     /// the same one here. Since that isn't stored (at least, not that I know of), this onus is on the
     /// user.
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        let db = connect(&LanceBackend::get_db_path())
+        let db = connect(&self.get_db_path())
             .execute()
             .await
             .map_err(|e| LanceError::ConnectionError(e.to_string()))?;
@@ -286,10 +285,12 @@ impl VectorBackend for LanceBackend {
                 self.delete_rows(key, &duplicate_keys).await?;
             }
 
-            return Ok(deleted_count);
+            Ok(deleted_count)
+        } else {
+            Err(LanceError::ParameterError(format!(
+                "column '{by}' or '{key}' not found in schema"
+            )))
         }
-
-        Ok(0)
     }
 
     /// Return all the rows in the LanceDB table, selecting only the columns specified. This is useful
@@ -313,7 +314,7 @@ impl VectorBackend for LanceBackend {
     /// * `LanceError::Other` - If the query execution fails
     async fn get_items<'a>(
         &'a self,
-        columns: &'a [impl AsRef<str> + Send + Sync],
+        columns: &'a [impl AsRef<str> + Send + Sync + Display],
     ) -> Result<Vec<Self::Record>, Self::Error> {
         let db = self.connect().await?;
 
@@ -441,7 +442,7 @@ impl VectorBackend for LanceBackend {
         &'a self,
         key_col: &'a str,
         key: &'a str,
-    ) -> Result<Self::Record, Self::Error> {
+    ) -> Result<Option<Self::Record>, Self::Error> {
         let db = self.connect().await?;
 
         let tbl = db
@@ -467,10 +468,9 @@ impl VectorBackend for LanceBackend {
             .await
             .map_err(|e| LanceError::QueryError(e.to_string()))?;
 
-        Ok(batches
-            .first()
-            .cloned()
-            .unwrap_or(RecordBatch::new_empty(Arc::clone(&self.schema))))
+        Ok(Some(batches.first().cloned().unwrap_or(
+            RecordBatch::new_empty(Arc::clone(&self.schema)),
+        )))
     }
 
     /// Given the name of a column and some values, return the rows with any matching values.
@@ -544,6 +544,10 @@ impl VectorBackend for LanceBackend {
         merge_on: Option<&'a [&str]>,
         source_col: &'a str,
     ) -> Result<(), Self::Error> {
+        if items.is_empty() {
+            return Ok(());
+        }
+
         let db = self.connect().await?;
 
         if self.db_exists().await

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -1,0 +1,590 @@
+//! LanceDB vector backend implementation.
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::Float32Type;
+use futures::TryStreamExt;
+use lancedb::database::CreateTableMode;
+use lancedb::embeddings::EmbeddingDefinition;
+use std::collections::HashSet;
+use std::fmt::Display;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow_array::{RecordBatch, RecordBatchIterator, StringArray};
+
+use arrow_schema::{ArrowError, Schema};
+use lancedb::query::{ExecutableQuery, QueryBase};
+use lancedb::{Connection, Error as LanceDbError, connect, index::scalar::FtsIndexBuilder};
+use thiserror::Error;
+
+use crate::{
+    embedding::common::EmbeddingProviderConfig, providers::registry::provider_registry,
+    vector::backends::backend::VectorBackend,
+};
+
+// NOTE: Maintainers: ensure that `DB_URI` begins with `TABLE_NAME`
+
+/// The URI for the LanceDB table. This is the default location for the table, and for now cannot
+/// be changed.
+pub const LANCEDB_URI: &str = "data/lancedb-table";
+
+/// The name of the table. This is the default table name, and for now cannot be changed.
+pub const LANCE_TABLE_NAME: &str = "data";
+
+/// Errors that can occur when working with LanceDB
+#[derive(Debug, Error)]
+pub enum LanceError {
+    /// Error connecting to LanceDB
+    #[error("LanceDB connection error: {0}")]
+    ConnectionError(String),
+    /// Error running some query
+    #[error("Failed to execute query: {0}")]
+    QueryError(String),
+    /// Error creating or updating a table in LanceDB
+    #[error("LanceDB table update error: {0}")]
+    TableUpdateError(String),
+    /// Invalid params
+    #[error("Invalid parameter: {0}")]
+    ParameterError(String),
+    /// The database is in an invalid state
+    #[error("The DB is in an invalid state: {0}")]
+    InvalidStateError(String),
+    /// IO errors, used by repair.rs.
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+    /// Arrow errors, used by repair.rs.
+    #[error(transparent)]
+    ArrowError(#[from] ArrowError),
+    /// Other LanceDB-related errors
+    #[error(transparent)]
+    Other(#[from] LanceDbError),
+}
+
+/// Backend for LanceDB vector store.
+pub struct LanceBackend {
+    /// Configuration for the LanceDB embedding provider.
+    config: EmbeddingProviderConfig,
+    /// Arrow schema for the LanceDB table.:w
+    schema: Arc<Schema>,
+}
+
+impl LanceBackend {
+    /// From a `RecordBatch`, return all values from a specified column as a `Vec<String>`.
+    ///
+    /// # Arguments
+    ///
+    /// * `batch`: A reference to a `RecordBatch`.
+    /// * `column`: The index of the column to use.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<String>` containing all the items in the specified column of the `RecordBatch`.
+    #[must_use]
+    pub fn get_column_from_batch(batch: &RecordBatch, column: usize) -> Vec<String> {
+        let results = batch.column(column).as_string::<i32>();
+
+        results
+            .iter()
+            .filter_map(|s| Some(s?.to_string()))
+            .collect()
+    }
+}
+
+impl VectorBackend for LanceBackend {
+    type Record = RecordBatch;
+    type EmbeddingColumn = Vec<RecordBatch>;
+    type Error = LanceError;
+    type Config = EmbeddingProviderConfig;
+    type Connection = Connection;
+
+    /// Returns the database URI, allowing override via `LANCEDB_URI` environment variable.
+    fn get_db_path() -> String {
+        std::env::var("LANCEDB_URI").unwrap_or_else(|_| LANCEDB_URI.to_string())
+    }
+
+    /// Checks if an existing LanceDB exists and has a valid table
+    async fn db_exists(&self) -> bool {
+        let uri = LanceBackend::get_db_path();
+        if !PathBuf::from(&uri).exists() {
+            return false;
+        }
+
+        // Check if we can actually connect and open the table
+        let db_result = connect(&uri).execute().await;
+        if let Ok(db) = db_result {
+            db.open_table(LANCE_TABLE_NAME).execute().await.is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Create indices for the database. This function creates two indices: an IVF-PQ index on the
+    /// embedding column, and a FTS index on the text column. This allows for full-text search as well
+    /// as more efficient vector searches. If indices already exist, they are optimized instead.
+    ///
+    /// # Arguments:
+    ///
+    /// * `text_col` - The name of the column containing text
+    /// * `embedding_col` - The name of the embedding column
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database connection fails, table operations fail, or index creation fails.
+    async fn create_or_update_indices<'a>(
+        text_col: &'a str,
+        embedding_col: &'a str,
+    ) -> Result<(), Self::Error> {
+        let db = connect(&LanceBackend::get_db_path())
+            .execute()
+            .await
+            .map_err(|e| LanceError::ConnectionError(e.to_string()))?;
+
+        let tbl = db.open_table(LANCE_TABLE_NAME).execute().await?;
+
+        let indices = tbl.list_indices().await?;
+        let has_vector_index = indices
+            .iter()
+            .any(|i| i.columns.as_slice() == [embedding_col]);
+        let has_fts_index = indices.iter().any(|i| i.columns.as_slice() == [text_col]);
+
+        if !has_vector_index {
+            tbl.create_index(&[embedding_col], lancedb::index::Index::Auto)
+                .execute()
+                .await?;
+        }
+
+        if !has_fts_index {
+            // Note that currently, multi-column indexes are not supported by LanceDB.
+            tbl.create_index(
+                &[text_col],
+                lancedb::index::Index::FTS(FtsIndexBuilder::default()),
+            )
+            .execute()
+            .await?;
+        }
+
+        // If both indices already existed before this run, they could be optimized here
+        // but optimization is optional and can be done separately.
+        Ok(())
+    }
+
+    /// Connect to the Lance database and add the embedding `embedding_name` to the database's
+    /// embedding registry. Note that if we are opening a database that had one defined, we should use
+    /// the same one here. Since that isn't stored (at least, not that I know of), this onus is on the
+    /// user.
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let db = connect(&LanceBackend::get_db_path())
+            .execute()
+            .await
+            .map_err(|e| LanceError::ConnectionError(e.to_string()))?;
+        let registry = provider_registry();
+
+        registry
+            .register_embedding_with_lancedb(&db, &self.config)
+            .map_err(|e| LanceError::ConnectionError(e.to_string()))?;
+        Ok(db)
+    }
+
+    /// Given a column name and a list of key values, delete all matching rows from the database.
+    ///
+    /// # Arguments
+    ///
+    /// * `col` - The name of the column to match against.
+    /// * `keys` - The list of values to delete. Rows whose `col` value is in this list are deleted.
+    ///
+    /// # Errors
+    ///
+    /// * `LanceError::ConnectionError` - If the database connection fails
+    /// * `LanceError::InvalidStateError` - If the table doesn't exist
+    /// * `LanceError::Other` - If the delete query fails
+    async fn delete_rows<'a>(
+        &'a self,
+        col: &str,
+        keys: &'a [impl AsRef<str> + Send + Sync],
+    ) -> Result<(), Self::Error> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+
+        let db = self.connect().await?;
+        let table = db
+            .open_table(LANCE_TABLE_NAME)
+            .execute()
+            .await
+            .map_err(|_| {
+                LanceError::InvalidStateError(format!(
+                    "The table {LANCE_TABLE_NAME} does not exist"
+                ))
+            })?;
+
+        for key_chunk in keys.chunks(100) {
+            let delete_pred = key_chunk
+                .iter()
+                .map(|k| format!("{col} = '{}'", k.as_ref().replace('\'', "''")))
+                .collect::<Vec<_>>()
+                .join(" OR ");
+
+            table.delete(&delete_pred).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Deduplicate rows in the LanceDB table based on a 'by' column, keeping only the first
+    /// occurrence of each unique 'by' value and deleting the duplicates.
+    ///
+    /// # Arguments
+    ///
+    /// * `by` - Column name to deduplicate by
+    /// * `key` - Column name to use as the key for deletion
+    ///
+    /// # Returns
+    ///
+    /// Number of rows deleted
+    ///
+    /// # Errors
+    ///
+    /// * `LanceError::InvalidStateError` if the table cannot be opened
+    /// * `LanceError::ConnectionError` if the database connection fails
+    /// * `LanceError::InvalidStateError` if the table doesn't exist
+    /// * `LanceError::ParameterError` if the key column is not found in the rows
+    /// * `LanceError::Other` for other LanceDB errors
+    async fn dedup_rows<'a>(&'a self, by: &'a str, key: &'a str) -> Result<usize, Self::Error> {
+        let db = self.connect().await?;
+        let table = db
+            .open_table(LANCE_TABLE_NAME)
+            .execute()
+            .await
+            .map_err(|_| {
+                LanceError::InvalidStateError(format!(
+                    "The table {LANCE_TABLE_NAME} does not exist"
+                ))
+            })?;
+
+        if let Some((by_idx, _)) = self.schema.column_with_name(by)
+            && let Some((key_idx, _)) = self.schema.column_with_name(key)
+        {
+            let mut stream = table.query().execute().await?;
+            let mut seen_by_values = HashSet::new();
+            let mut duplicate_keys = Vec::new();
+
+            while let Some(batch) = stream.try_next().await? {
+                let by_values = LanceBackend::get_column_from_batch(&batch, by_idx);
+                let key_values = LanceBackend::get_column_from_batch(&batch, key_idx);
+
+                for (by_val, key_val) in by_values.into_iter().zip(key_values) {
+                    if !seen_by_values.insert(by_val) {
+                        duplicate_keys.push(key_val);
+                    }
+                }
+            }
+
+            // Delete duplicate rows
+            let deleted_count = duplicate_keys.len();
+            if !duplicate_keys.is_empty() {
+                self.delete_rows(key, &duplicate_keys).await?;
+            }
+
+            return Ok(deleted_count);
+        }
+
+        Ok(0)
+    }
+
+    /// Return all the rows in the LanceDB table, selecting only the columns specified. This is useful
+    /// for computing what rows do *not* exist in the table, such as in cases where the data source has
+    /// new items. Note that LanceDB by default seems to chunk by 1024 items, so if you're certain you
+    /// will receive fewer than 1024 rows, it is safe to assume only one element exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `columns`: The set of columns to return. Typically, you do not want to include the full-text
+    ///   column here.
+    ///
+    /// # Returns
+    ///
+    /// A vector of Arrow `RecordBatch` objects containing the results.
+    ///
+    /// # Errors
+    ///
+    /// * `LanceError::ConnectionError` - If the database connection fails
+    /// * `LanceError::InvalidStateError` - If the table doesn't exist
+    /// * `LanceError::Other` - If the query execution fails
+    async fn get_items<'a>(
+        &'a self,
+        columns: &'a [impl AsRef<str> + Send + Sync],
+    ) -> Result<Vec<Self::Record>, Self::Error> {
+        let db = self.connect().await?;
+
+        let tbl = db
+            .open_table(LANCE_TABLE_NAME)
+            .execute()
+            .await
+            .map_err(|_| {
+                LanceError::InvalidStateError(format!(
+                    "The table {LANCE_TABLE_NAME} does not exist"
+                ))
+            })?;
+
+        let string_cols: Vec<String> = columns.iter().map(|c| c.as_ref().to_string()).collect();
+
+        // The installed version of LanceDB has a bug where without the `.limit` call here, it only
+        // returns 10 rows; see https://github.com/lancedb/lancedb/issues/1852#issuecomment-2489837804
+        let results: Vec<RecordBatch> = tbl
+            .query()
+            .select(lancedb::query::Select::Columns(string_cols))
+            .limit(tbl.count_rows(None).await?)
+            .execute()
+            .await?
+            .try_collect()
+            .await?;
+
+        Ok(results)
+    }
+
+    /// Perform a vector search on the database using the `query` and the `embedding_name` embedding
+    /// method. Returns a vector of Arrow `RecordBatch` objects containing the results.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query string to search for
+    /// * `limit` - Limit on the number of returned results
+    ///
+    /// # Returns
+    ///
+    /// A vector of Arrow `RecordBatch` objects containing the results.
+    ///
+    /// # Errors
+    ///
+    /// * `LanceError::ParameterError` - If the embedding provider is not recognized
+    /// * `LanceError::ConnectionError` - If the database connection fails
+    /// * `LanceError::InvalidStateError` - If the table doesn't exist or embedding provider not in registry
+    /// * `LanceError::Other` - If embedding computation or query execution fails
+    async fn vector_search(
+        &self,
+        query: String,
+        limit: usize,
+    ) -> Result<Vec<Self::Record>, Self::Error> {
+        let start_time = Instant::now();
+        let db = self.connect().await?;
+
+        let tbl = db
+            .open_table(LANCE_TABLE_NAME)
+            .execute()
+            .await
+            .map_err(|_| {
+                LanceError::InvalidStateError(format!(
+                    "The table {LANCE_TABLE_NAME} does not exist"
+                ))
+            })?;
+        log::debug!("Opening the DB and table took {:.1?}", start_time.elapsed());
+
+        let start_time = Instant::now();
+        let embedding = db
+            .embedding_registry()
+            .get(self.config.provider_id().as_str())
+            .ok_or(LanceError::InvalidStateError(format!(
+                "{} is not in the database embedding registry",
+                self.config.provider_id().as_str()
+            )))?;
+
+        let query_vec =
+            embedding.compute_query_embeddings(Arc::new(StringArray::from(vec![query])))?;
+        log::debug!("Computing embeddings took {:.1?}", start_time.elapsed());
+
+        // Convert FixedSizeListArray to Vec<f32>
+        // The embedding functions return `FixedSizeListArray` with Float32 elements
+        // See https://github.com/apache/arrow-rs/discussions/6087#discussioncomment-10851422 for
+        // converting an Arrow Array to a `Vec`.
+        let query_vec: Vec<f32> = {
+            let list_array = arrow_array::cast::as_fixed_size_list_array(&query_vec);
+            let values = list_array.values().as_primitive::<Float32Type>();
+            values.iter().map(|v| v.unwrap_or(0.0)).collect()
+        };
+
+        let start_time = Instant::now();
+        let stream = tbl
+            .query()
+            .limit(limit)
+            .nearest_to(query_vec)?
+            .execute()
+            .await?;
+        let batches: Vec<RecordBatch> = stream.try_collect().await?;
+        log::debug!("Vector search took {:.1?}", start_time.elapsed());
+
+        Ok(batches)
+    }
+
+    /// Given the name of the key column and the value of a row's key, return the row with that key if
+    /// it exists, or `None` otherwise. The returned row is returned as a single `RecordBatch`.
+    ///
+    /// Technically, there's nothing *requiring* you to specify a key as a column name; you could very
+    /// well specify any arbitrary column and use this, but note that even if multiple rows match, this
+    /// limits the result to one item, and that returned value may change across LanceDB versions, so
+    /// you should not rely on that behavior.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_col` - The name of the column that's the DB key.
+    /// * `key` - The value of the key for the row to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// The row with the specified `key`, if it exists, or `None` if no matching row was found.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`LanceError`] if the database connection fails, the table cannot be opened,
+    /// the query cannot be executed, or the result stream cannot be collected.
+    async fn search_by_key<'a>(
+        &'a self,
+        key_col: &'a str,
+        key: &'a str,
+    ) -> Result<Self::Record, Self::Error> {
+        let db = self.connect().await?;
+
+        let tbl = db
+            .open_table(LANCE_TABLE_NAME)
+            .execute()
+            .await
+            .map_err(|_| {
+                LanceError::InvalidStateError(format!(
+                    "The table {LANCE_TABLE_NAME} does not exist"
+                ))
+            })?;
+
+        let stream = tbl
+            .query()
+            .only_if(format!("{key_col} = '{}'", key.replace('\'', "''")))
+            .limit(1)
+            .execute()
+            .await
+            .map_err(|e| LanceError::QueryError(e.to_string()))?;
+
+        let batches: Vec<RecordBatch> = stream
+            .try_collect()
+            .await
+            .map_err(|e| LanceError::QueryError(e.to_string()))?;
+
+        Ok(batches
+            .first()
+            .cloned()
+            .unwrap_or(RecordBatch::new_empty(Arc::clone(&self.schema))))
+    }
+
+    /// Given the name of a column and some values, return the rows with any matching values.
+    ///
+    /// # Arguments
+    ///
+    /// * `col` - The name of the column that's the DB key.
+    /// * `values` - The values to match.
+    ///
+    /// # Returns
+    ///
+    /// The rows with the specified `values`.
+    ///
+    /// # Errors
+    ///
+    /// * `LanceError::ConnectionError` - If the DB connection failed.
+    /// * `LanceError::InvalidStateError` - If opening the table failed.
+    /// * `LanceError::Other` - If query execution failed.
+    async fn search_by_column<'a>(
+        &'a self,
+        col: &'a str,
+        values: &'a [impl AsRef<str> + Send + Sync + Display],
+    ) -> Result<Vec<Self::Record>, Self::Error> {
+        if values.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let db = self.connect().await?;
+        let tbl = db
+            .open_table(LANCE_TABLE_NAME)
+            .execute()
+            .await
+            .map_err(|_| {
+                LanceError::InvalidStateError(format!(
+                    "The table {LANCE_TABLE_NAME} does not exist"
+                ))
+            })?;
+
+        let queries = values
+            .iter()
+            .map(|key| format!("{col} = '{}'", key.as_ref().replace('\'', "''")))
+            .collect::<Vec<_>>()
+            .join(" OR ");
+
+        let stream = tbl.query().only_if(queries).execute().await?;
+        stream.try_collect().await.map_err(Into::into)
+    }
+
+    /// Creates and initializes a LanceDB table for vector storage.
+    ///
+    /// Connects to LanceDB at the default location, creates a table named `TABLE_NAME`,
+    /// and registers embedding functions for OpenAI. If this table already exists,
+    /// it simply opens it and upserts the data; otherwise, it inserts the data into the newly created
+    /// table.
+    ///
+    /// # Arguments
+    ///
+    /// * `items` - A vector of `Record` items to insert into the database.
+    /// * `merge_on` - `None` if you want to create or overwrite the current database; otherwise, a
+    ///   reference to an array of keys to merge on.
+    /// * `source_col` - The name of the column in `items` that contains the source document text.
+    ///
+    /// # Returns
+    /// A Connection to the LanceDB database if successful
+    ///
+    /// # Errors
+    /// Returns a `LanceError` if connection, table creation, or registering embedding functions fails
+    async fn insert_items<'a>(
+        &'a self,
+        items: Vec<Self::Record>,
+        merge_on: Option<&'a [&str]>,
+        source_col: &'a str,
+    ) -> Result<(), Self::Error> {
+        let db = self.connect().await?;
+
+        if self.db_exists().await
+            && let Some(merge_on) = merge_on
+            && let Some(first_batch) = items.first()
+        {
+            // Add rows if they don't already exist
+            let tbl = db
+                .open_table(LANCE_TABLE_NAME)
+                .execute()
+                .await
+                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+
+            let schema = first_batch.schema();
+
+            let reader = RecordBatchIterator::new(
+                items.into_iter().map(std::result::Result::Ok),
+                schema.clone(),
+            );
+            tbl.merge_insert(merge_on)
+                .when_not_matched_insert_all()
+                .clone()
+                .execute(Box::new(reader))
+                .await
+                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+        } else {
+            let embedding_params = EmbeddingDefinition::new(
+                source_col,
+                self.config.provider_id().as_str(),
+                Some("embeddings"),
+            );
+
+            // Create a new table and add rows
+            db.create_table(LANCE_TABLE_NAME, items)
+                .mode(CreateTableMode::Overwrite)
+                .add_embedding(embedding_params)?
+                .execute()
+                .await
+                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+}

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -1,7 +1,6 @@
 //! LanceDB vector backend implementation.
 
 use std::collections::HashSet;
-use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -10,6 +9,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::types::Float32Type;
 use arrow_array::{RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{ArrowError, Schema};
+use async_trait::async_trait;
 use futures::TryStreamExt;
 use lancedb::database::CreateTableMode;
 use lancedb::embeddings::EmbeddingDefinition;
@@ -66,13 +66,20 @@ pub struct LanceBackend {
     config: EmbeddingProviderConfig,
     /// Arrow schema for the LanceDB table.
     schema: Arc<Schema>,
+    /// Column name containing the source text used to generate embeddings.
+    source_col: String,
 }
 
 impl LanceBackend {
-    /// Creates a new `LanceBackend` with the given embedding provider config and Arrow schema.
+    /// Creates a new `LanceBackend` with the given embedding provider config, Arrow schema, and
+    /// source column name.
     #[must_use]
-    pub fn new(config: EmbeddingProviderConfig, schema: Arc<Schema>) -> Self {
-        Self { config, schema }
+    pub fn new(config: EmbeddingProviderConfig, schema: Arc<Schema>, source_col: String) -> Self {
+        Self {
+            config,
+            schema,
+            source_col,
+        }
     }
 
     /// From a `RecordBatch`, return all values from a specified column as a `Vec<String>`.
@@ -96,6 +103,7 @@ impl LanceBackend {
     }
 }
 
+#[async_trait]
 impl VectorBackend for LanceBackend {
     type Record = RecordBatch;
     type Error = LanceError;
@@ -135,16 +143,12 @@ impl VectorBackend for LanceBackend {
     /// # Errors
     ///
     /// Returns an error if the database connection fails, table operations fail, or index creation fails.
-    async fn create_or_update_indices<'a>(
-        &'a self,
-        text_col: &'a str,
-        embedding_col: &'a str,
+    async fn create_or_update_indices(
+        &self,
+        text_col: &str,
+        embedding_col: &str,
     ) -> Result<(), Self::Error> {
-        let db = connect(&self.get_db_path())
-            .execute()
-            .await
-            .map_err(|e| LanceError::ConnectionError(e.to_string()))?;
-
+        let db = self.connect().await?;
         let tbl = db.open_table(LANCE_TABLE_NAME).execute().await?;
 
         let indices = tbl.list_indices().await?;
@@ -203,14 +207,14 @@ impl VectorBackend for LanceBackend {
     /// * `LanceError::ConnectionError` - If the database connection fails
     /// * `LanceError::InvalidStateError` - If the table doesn't exist
     /// * `LanceError::Other` - If the delete query fails
-    async fn delete_rows<'a>(
-        &'a self,
-        col: &str,
-        keys: &'a [impl AsRef<str> + Send + Sync],
-    ) -> Result<(), Self::Error> {
+    async fn delete_rows(&self, col: &str, keys: &[String]) -> Result<(), Self::Error> {
         if keys.is_empty() {
             return Ok(());
         }
+
+        let col = self.schema.field_with_name(col).map_err(|_| {
+            LanceError::ParameterError(format!("Column {col} does not exist in the schema"))
+        })?;
 
         let db = self.connect().await?;
         let table = db
@@ -226,7 +230,7 @@ impl VectorBackend for LanceBackend {
         for key_chunk in keys.chunks(100) {
             let delete_pred = key_chunk
                 .iter()
-                .map(|k| format!("{col} = '{}'", k.as_ref().replace('\'', "''")))
+                .map(|k| format!("{col} = '{}'", k.replace('\'', "''")))
                 .collect::<Vec<_>>()
                 .join(" OR ");
 
@@ -255,7 +259,7 @@ impl VectorBackend for LanceBackend {
     /// * `LanceError::InvalidStateError` if the table doesn't exist
     /// * `LanceError::ParameterError` if the key column is not found in the rows
     /// * `LanceError::Other` for other LanceDB errors
-    async fn dedup_rows<'a>(&'a self, by: &'a str, key: &'a str) -> Result<usize, Self::Error> {
+    async fn dedup_rows(&self, by: &str, key: &str) -> Result<usize, Self::Error> {
         let db = self.connect().await?;
         let table = db
             .open_table(LANCE_TABLE_NAME)
@@ -318,10 +322,7 @@ impl VectorBackend for LanceBackend {
     /// * `LanceError::ConnectionError` - If the database connection fails
     /// * `LanceError::InvalidStateError` - If the table doesn't exist
     /// * `LanceError::Other` - If the query execution fails
-    async fn get_items<'a>(
-        &'a self,
-        columns: &'a [impl AsRef<str> + Send + Sync + Display],
-    ) -> Result<Vec<Self::Record>, Self::Error> {
+    async fn get_items(&self, columns: &[String]) -> Result<Vec<Self::Record>, Self::Error> {
         let db = self.connect().await?;
 
         let tbl = db
@@ -334,7 +335,7 @@ impl VectorBackend for LanceBackend {
                 ))
             })?;
 
-        let string_cols: Vec<String> = columns.iter().map(|c| c.as_ref().to_string()).collect();
+        let string_cols = columns.to_vec();
 
         // The installed version of LanceDB has a bug where without the `.limit` call here, it only
         // returns 10 rows; see https://github.com/lancedb/lancedb/issues/1852#issuecomment-2489837804
@@ -444,10 +445,10 @@ impl VectorBackend for LanceBackend {
     ///
     /// Returns a [`LanceError`] if the database connection fails, the table cannot be opened,
     /// the query cannot be executed, or the result stream cannot be collected.
-    async fn search_by_key<'a>(
-        &'a self,
-        key_col: &'a str,
-        key: &'a str,
+    async fn search_by_key(
+        &self,
+        key_col: &str,
+        key: &str,
     ) -> Result<Option<Self::Record>, Self::Error> {
         let db = self.connect().await?;
 
@@ -493,10 +494,10 @@ impl VectorBackend for LanceBackend {
     /// * `LanceError::ConnectionError` - If the DB connection failed.
     /// * `LanceError::InvalidStateError` - If opening the table failed.
     /// * `LanceError::Other` - If query execution failed.
-    async fn search_by_column<'a>(
-        &'a self,
-        col: &'a str,
-        values: &'a [impl AsRef<str> + Send + Sync + Display],
+    async fn search_by_column(
+        &self,
+        col: &str,
+        values: &[String],
     ) -> Result<Vec<Self::Record>, Self::Error> {
         if values.is_empty() {
             return Ok(Vec::new());
@@ -515,7 +516,7 @@ impl VectorBackend for LanceBackend {
 
         let queries = values
             .iter()
-            .map(|key| format!("{col} = '{}'", key.as_ref().replace('\'', "''")))
+            .map(|key| format!("{col} = '{}'", key.replace('\'', "''")))
             .collect::<Vec<_>>()
             .join(" OR ");
 
@@ -535,18 +536,18 @@ impl VectorBackend for LanceBackend {
     /// * `items` - A vector of `Record` items to insert into the database.
     /// * `merge_on` - `None` if you want to create or overwrite the current database; otherwise, a
     ///   reference to an array of keys to merge on.
-    /// * `source_col` - The name of the column in `items` that contains the source document text.
     ///
     /// # Returns
+    ///
     /// `Ok(())` if the items were inserted successfully
     ///
     /// # Errors
+    ///
     /// Returns a `LanceError` if connection, table creation, or registering embedding functions fails
-    async fn insert_items<'a>(
-        &'a self,
+    async fn insert_items(
+        &self,
         items: Vec<Self::Record>,
-        merge_on: Option<&'a [&str]>,
-        source_col: &'a str,
+        merge_on: Option<&[&str]>,
     ) -> Result<(), Self::Error> {
         if items.is_empty() {
             return Ok(());
@@ -579,7 +580,7 @@ impl VectorBackend for LanceBackend {
                 .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
         } else {
             let embedding_params = EmbeddingDefinition::new(
-                source_col,
+                self.source_col.as_str(),
                 self.config.provider_id().as_str(),
                 Some("embeddings"),
             );

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -69,6 +69,12 @@ pub struct LanceBackend {
 }
 
 impl LanceBackend {
+    /// Creates a new `LanceBackend` with the given embedding provider config and Arrow schema.
+    #[must_use]
+    pub fn new(config: EmbeddingProviderConfig, schema: Arc<Schema>) -> Self {
+        Self { config, schema }
+    }
+
     /// From a `RecordBatch`, return all values from a specified column as a `Vec<String>`.
     ///
     /// # Arguments
@@ -468,9 +474,7 @@ impl VectorBackend for LanceBackend {
             .await
             .map_err(|e| LanceError::QueryError(e.to_string()))?;
 
-        Ok(Some(batches.first().cloned().unwrap_or(
-            RecordBatch::new_empty(Arc::clone(&self.schema)),
-        )))
+        Ok(batches.into_iter().next())
     }
 
     /// Given the name of a column and some values, return the rows with any matching values.
@@ -534,7 +538,7 @@ impl VectorBackend for LanceBackend {
     /// * `source_col` - The name of the column in `items` that contains the source document text.
     ///
     /// # Returns
-    /// A Connection to the LanceDB database if successful
+    /// `Ok(())` if the items were inserted successfully
     ///
     /// # Errors
     /// Returns a `LanceError` if connection, table creation, or registering embedding functions fails

--- a/zqa-rag/src/vector/backends/mod.rs
+++ b/zqa-rag/src/vector/backends/mod.rs
@@ -1,0 +1,4 @@
+//! Vector backend traits and implementations.
+
+pub mod backend;
+pub mod lance;

--- a/zqa-rag/src/vector/mod.rs
+++ b/zqa-rag/src/vector/mod.rs
@@ -1,5 +1,6 @@
 //! Utilities for working with LanceDB.
 
+pub mod backends;
 pub mod backup;
 pub mod checkhealth;
 pub mod doctor;

--- a/zqa-rag/src/vector/mod.rs
+++ b/zqa-rag/src/vector/mod.rs
@@ -1,4 +1,4 @@
-//! Utilities for working with LanceDB.
+//! Vector database utilities and backend abstractions.
 
 pub mod backends;
 pub mod backup;


### PR DESCRIPTION
This is part of a refactor to eventually support ZOT-161 and ZOT-162. This PR creates the trait and as a proof-of-concept, implements it for LanceDB to match the existing behavior.

Actual migration to this trait will be in a future PR; that PR will also be responsible for moving tests here, since the old file will be deleted.

PR Reviewers: You should also assess whether the new traits have good, idiomatic design to integrate with more backends such as Cloud SQL, BigQuery, or other vector DBs like Qdrant.