### PR TITLE
feat: add Voyage AI batch embedding API support to zqa CLI

### DIFF
--- a/zqa-rag/src/embedding/batch_adapter.rs
+++ b/zqa-rag/src/embedding/batch_adapter.rs
@@ -1,0 +1,150 @@
+//! Provider-agnostic adapter for batch embedding APIs.
+//!
+//! To add support for a new batch embedding provider, add a new variant to [`BatchProviderAdapter`]
+//! and implement the three high-level methods (`submit_texts`, `get_status`, `collect_embeddings`)
+//! for it.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    capabilities::{BatchAPIProvider, BatchJobState},
+    embedding::{
+        common::EmbeddingProviderConfig,
+        voyage::{VoyageAIClient, VoyageAIFilesRequest, VoyageAIFilesRequestBody},
+    },
+    http_client::ReqwestClient,
+    llm::errors::LLMError,
+};
+
+/// Metadata about a pending batch embedding job.
+///
+/// This is serialized to disk so the user can check status and collect results in a later CLI
+/// session, without needing to keep the CLI running while the batch processes.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchJobMetadata {
+    /// The provider-assigned batch identifier.
+    pub batch_id: String,
+    /// The name of the embedding provider that owns this batch (e.g. `"voyageai"`).
+    pub provider: String,
+    /// Number of texts in each submitted request, in submission order.
+    ///
+    /// Used to reconstruct the flat embedding list from per-request results when collecting.
+    pub request_sizes: Vec<usize>,
+    /// Total number of texts submitted.
+    pub total_texts: usize,
+}
+
+/// A provider-agnostic adapter for batch embedding APIs.
+///
+/// Each variant wraps the concrete client for that provider. To support a new batch embedding
+/// provider, add a variant here and implement the three methods below.
+///
+/// The inner client types are `pub(crate)` implementation details; external code constructs
+/// instances exclusively via [`BatchProviderAdapter::from_embedding_config`].
+#[allow(private_interfaces)]
+pub enum BatchProviderAdapter {
+    /// Voyage AI batch API.
+    VoyageAI(VoyageAIClient<ReqwestClient>),
+}
+
+impl BatchProviderAdapter {
+    /// Texts per request when submitting to the Voyage AI batch API.
+    ///
+    /// Each Voyage AI request is capped at 120K tokens with a 32K context window per document,
+    /// so three documents per request is the safe maximum.
+    const VOYAGE_BATCH_SIZE: usize = 3;
+
+    /// Construct a [`BatchProviderAdapter`] from an [`EmbeddingProviderConfig`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LLMError::GenericLLMError`] if the configured provider does not expose a batch API.
+    pub fn from_embedding_config(config: &EmbeddingProviderConfig) -> Result<Self, LLMError> {
+        match config {
+            EmbeddingProviderConfig::VoyageAI(cfg) => {
+                Ok(Self::VoyageAI(VoyageAIClient::with_config(cfg.clone())))
+            }
+            _ => Err(LLMError::GenericLLMError(format!(
+                "Batch API is not supported for provider '{}'",
+                config.provider_name()
+            ))),
+        }
+    }
+
+    /// Submit a flat list of texts to the batch embedding API.
+    ///
+    /// Internally, texts are grouped into provider-appropriate request chunks. The returned
+    /// [`BatchJobMetadata`] records the batch ID and the chunk layout so results can be
+    /// reassembled in the original order during [`Self::collect_embeddings`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from the underlying provider's [`BatchAPIProvider::submit_batch`].
+    pub async fn submit_texts(&self, texts: Vec<String>) -> Result<BatchJobMetadata, LLMError> {
+        match self {
+            Self::VoyageAI(client) => {
+                let batch_size = Self::VOYAGE_BATCH_SIZE;
+                let request_sizes: Vec<usize> =
+                    texts.chunks(batch_size).map(<[_]>::len).collect();
+                let total_texts = texts.len();
+
+                let requests: Vec<VoyageAIFilesRequest> = texts
+                    .chunks(batch_size)
+                    .enumerate()
+                    .map(|(i, chunk)| VoyageAIFilesRequest {
+                        custom_id: format!("req-{i}"),
+                        body: VoyageAIFilesRequestBody {
+                            input: chunk.to_vec(),
+                        },
+                    })
+                    .collect();
+
+                let response = client.submit_batch(requests).await?;
+
+                Ok(BatchJobMetadata {
+                    batch_id: response.id,
+                    provider: "voyageai".to_string(),
+                    request_sizes,
+                    total_texts,
+                })
+            }
+        }
+    }
+
+    /// Return the current [`BatchJobState`] for the given `batch_id`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from the underlying provider's [`BatchAPIProvider::get_batch_status`].
+    pub async fn get_status(&self, batch_id: &str) -> Result<BatchJobState, LLMError> {
+        match self {
+            Self::VoyageAI(client) => BatchAPIProvider::get_batch_status(client, batch_id).await,
+        }
+    }
+
+    /// Collect embedding results for a completed batch.
+    ///
+    /// Returns a flat `Vec<Vec<f32>>` in the original text submission order, using the
+    /// `request_sizes` recorded in `metadata` to reconstruct position. Failed individual
+    /// requests are substituted with zero vectors.
+    ///
+    /// # Errors
+    ///
+    /// * [`LLMError::BatchNotCompleted`] — if the batch has not yet reached a terminal state.
+    /// * Propagates all other errors from the underlying provider.
+    pub async fn collect_embeddings(
+        &self,
+        metadata: &BatchJobMetadata,
+    ) -> Result<Vec<Vec<f32>>, LLMError> {
+        match self {
+            Self::VoyageAI(client) => {
+                client
+                    .collect_batch_embeddings_ordered(
+                        &metadata.batch_id,
+                        &metadata.request_sizes,
+                    )
+                    .await
+            }
+        }
+    }
+}

--- a/zqa-rag/src/embedding/common.rs
+++ b/zqa-rag/src/embedding/common.rs
@@ -152,6 +152,19 @@ impl EmbeddingProviderConfig {
             Self::ZeroEntropy(c) => &c.embedding_model,
         }
     }
+
+    /// Returns the embedding vector dimension for this provider's configured model.
+    #[must_use]
+    pub fn embedding_dims(&self) -> usize {
+        match self {
+            Self::OpenAI(c) => c.embedding_dims,
+            Self::VoyageAI(c) => c.embedding_dims,
+            Self::Gemini(c) => c.embedding_dims,
+            Self::Cohere(c) => c.embedding_dims,
+            Self::Ollama(c) => c.embedding_dims,
+            Self::ZeroEntropy(c) => c.embedding_dims,
+        }
+    }
 }
 
 /// A trait intended to be used for responses from embedding provider APIs. Typically, these APIs

--- a/zqa-rag/src/embedding/mod.rs
+++ b/zqa-rag/src/embedding/mod.rs
@@ -1,5 +1,6 @@
 //! Structs, traits, and implementations for embedding providers.
 
+pub mod batch_adapter;
 pub(crate) mod cohere;
 pub mod common;
 pub(crate) mod gemini;

--- a/zqa-rag/src/embedding/voyage.rs
+++ b/zqa-rag/src/embedding/voyage.rs
@@ -554,6 +554,67 @@ where
     }
 }
 
+impl<T> VoyageAIClient<T>
+where
+    T: HttpClient,
+{
+    /// Collect batch results and return embeddings ordered by original submission position.
+    ///
+    /// Results are re-assembled by parsing the `req-{i}` custom IDs set during
+    /// [`BatchAPIProvider::submit_batch`] and expanding each per-request result by the
+    /// corresponding entry in `request_sizes`. Failed requests are substituted with zero vectors.
+    ///
+    /// # Errors
+    ///
+    /// * `LLMError::BatchNotCompleted` - If the batch has not yet reached `Completed` or `Failed`
+    /// * All errors from [`VoyageAIClient::get_batch_results`]
+    pub(crate) async fn collect_batch_embeddings_ordered(
+        &self,
+        batch_id: &str,
+        request_sizes: &[usize],
+    ) -> Result<Vec<Vec<f32>>, LLMError> {
+        let (results, errors) = BatchAPIProvider::get_batch_results(self, batch_id).await?;
+
+        if let Some(errors) = &errors {
+            for err in errors {
+                log::warn!("Batch request '{}' failed", err.custom_id);
+            }
+        }
+
+        let output_dim = self
+            .config
+            .as_ref()
+            .map_or(DEFAULT_VOYAGE_EMBEDDING_DIM as usize, |c| c.embedding_dims);
+
+        // Index results by request number for O(1) lookup
+        let mut result_map: std::collections::HashMap<usize, VoyageAISuccess> =
+            std::collections::HashMap::new();
+        for result in results.unwrap_or_default() {
+            if let Some(idx_str) = result.custom_id.strip_prefix("req-")
+                && let Ok(idx) = idx_str.parse::<usize>()
+            {
+                result_map.insert(idx, result.response.body);
+            }
+        }
+
+        let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(request_sizes.iter().sum());
+        for (req_idx, &size) in request_sizes.iter().enumerate() {
+            if let Some(mut success) = result_map.remove(&req_idx) {
+                success.data.sort_by_key(|e| e.index);
+                for emb in success.data {
+                    embeddings.push(emb.embedding);
+                }
+            } else {
+                for _ in 0..size {
+                    embeddings.push(vec![0.0_f32; output_dim]);
+                }
+            }
+        }
+
+        Ok(embeddings)
+    }
+}
+
 impl<T> BatchAPIProvider for VoyageAIClient<T>
 where
     T: HttpClient,

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -690,6 +690,67 @@ impl VectorBackend for LanceBackend {
     }
 }
 
+impl LanceBackend {
+    /// Insert record batches that already contain a pre-computed `embeddings` column, bypassing
+    /// the embedding function entirely.
+    ///
+    /// This is the write path for the batch API workflow: embeddings are computed asynchronously
+    /// by an external service and then written to the database in a later CLI session.
+    ///
+    /// When the database already exists and `merge_on` is provided, records are upserted via
+    /// `merge_insert` (same as [`VectorBackend::insert_items`]). When the database does not yet
+    /// exist, the table is created directly from the batch schema — no embedding function is
+    /// registered, since `embeddings` values are already present in the batches.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`LanceError`] if connection, table creation, or data insertion fails.
+    pub async fn insert_precomputed_items(
+        &self,
+        items: Vec<RecordBatch>,
+        merge_on: Option<&[&str]>,
+    ) -> Result<(), LanceError> {
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        let db = self.connect().await?;
+
+        if self.db_exists().await
+            && let Some(merge_on) = merge_on
+            && let Some(first_batch) = items.first()
+        {
+            let tbl = db
+                .open_table(LANCE_TABLE_NAME)
+                .execute()
+                .await
+                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+
+            let schema = first_batch.schema();
+            let reader = RecordBatchIterator::new(
+                items.into_iter().map(std::result::Result::Ok),
+                schema.clone(),
+            );
+            tbl.merge_insert(merge_on)
+                .when_not_matched_insert_all()
+                .clone()
+                .execute(Box::new(reader))
+                .await
+                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+        } else {
+            // Create the table without an embedding function — the `embeddings` column
+            // is already populated in the supplied batches.
+            db.create_table(LANCE_TABLE_NAME, items)
+                .mode(CreateTableMode::Overwrite)
+                .execute()
+                .await
+                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::env;

--- a/zqa/src/cli/app.rs
+++ b/zqa/src/cli/app.rs
@@ -3,8 +3,11 @@ use std::sync::Arc;
 
 use rustyline::error::ReadlineError;
 
-use crate::cli::commands::{Command, parse_command};
+use crate::cli::commands::{BatchSubcommand, Command, parse_command};
 use crate::cli::errors::CLIError;
+use crate::cli::handlers::batch::{
+    handle_batch_collect_cmd, handle_batch_status_cmd, handle_batch_submit_cmd,
+};
 use crate::cli::handlers::cli::{
     handle_config_cmd, handle_help_cmd, handle_new_conversation_cmd, handle_quit_cmd,
 };
@@ -63,6 +66,13 @@ pub(crate) async fn dispatch_command<O: Write, E: Write>(
         Command::Config => handle_config_cmd(ctx),
         Command::Stats => handle_stats_cmd(ctx).await,
         Command::Search { query } => handle_search_cmd(query, ctx).await,
+        Command::Batch(BatchSubcommand::Submit) => handle_batch_submit_cmd(ctx).await,
+        Command::Batch(BatchSubcommand::Status { batch_id }) => {
+            handle_batch_status_cmd(batch_id, ctx).await
+        }
+        Command::Batch(BatchSubcommand::Collect { batch_id }) => {
+            handle_batch_collect_cmd(batch_id, ctx).await
+        }
         Command::Docs(subcmd) => handle_docs_cmd(subcmd, ctx),
     }
     .and(Ok(true))

--- a/zqa/src/cli/commands.rs
+++ b/zqa/src/cli/commands.rs
@@ -14,9 +14,16 @@ pub(crate) enum Command {
     Config,
     NewConversation,
     Quit,
+    Batch(BatchSubcommand),
     Docs(DocsCommand),
     Search { query: String },
     Query { text: String },
+}
+
+pub(crate) enum BatchSubcommand {
+    Submit,
+    Status { batch_id: Option<String> },
+    Collect { batch_id: Option<String> },
 }
 
 pub(crate) enum DocsCommand {
@@ -69,6 +76,26 @@ pub(crate) fn parse_command(command: &str) -> Result<Command, CommandParseError>
                 }
 
                 return Ok(Command::Embed { fix: true });
+            }
+
+            if let Some(rest) = query.strip_prefix("/batch") {
+                let rest = rest.trim();
+                let mut parts = rest.splitn(2, ' ');
+                let sub = parts.next().unwrap_or("");
+                let arg = parts.next().map(str::trim).filter(|s| !s.is_empty());
+
+                return match sub {
+                    "submit" => Ok(Command::Batch(BatchSubcommand::Submit)),
+                    "status" => Ok(Command::Batch(BatchSubcommand::Status {
+                        batch_id: arg.map(str::to_string),
+                    })),
+                    "collect" => Ok(Command::Batch(BatchSubcommand::Collect {
+                        batch_id: arg.map(str::to_string),
+                    })),
+                    _ => Err(CommandParseError::InvalidCommand(format!(
+                        "Invalid subcommand to /batch: '{rest}'. Valid subcommands: submit, status, collect."
+                    ))),
+                };
             }
 
             if let Some(subcmd) = query.strip_prefix("/docs") {

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -1,0 +1,298 @@
+//! Command handlers for batch embedding API operations.
+
+use std::{fs::File, io::Write, sync::Arc};
+
+use arrow_array::{FixedSizeListArray, Float32Array, RecordBatch};
+use arrow_ipc::reader::FileReader;
+use arrow_schema::{DataType, Field, Schema};
+use zqa_rag::{
+    capabilities::BatchJobState,
+    embedding::batch_adapter::{BatchJobMetadata, BatchProviderAdapter},
+};
+
+use crate::{
+    cli::{app::BATCH_ITER_FILE, errors::CLIError},
+    common::Context,
+};
+
+/// Path to the persisted batch job metadata file.
+pub(crate) const BATCH_JOB_FILE: &str = "batch_job.json";
+
+/// Handle `/batch submit` — read texts from `batch_iter.bin` and submit them to the batch API.
+///
+/// After submission, writes [`BatchJobMetadata`] to [`BATCH_JOB_FILE`] so the user can check
+/// status and collect results in a later session.
+///
+/// # Errors
+///
+/// Returns a [`CLIError`] if the batch file cannot be read, the provider does not support batch
+/// embeddings, the API call fails, or writing output fails.
+pub(crate) async fn handle_batch_submit_cmd<O: Write, E: Write>(
+    ctx: &mut Context<O, E>,
+) -> Result<(), CLIError> {
+    let file = File::open(BATCH_ITER_FILE).map_err(|_| {
+        CLIError::ConfigError(format!(
+            "Could not open {BATCH_ITER_FILE}. Run /process first to parse your library."
+        ))
+    })?;
+    let reader = FileReader::try_new(file, None)?;
+
+    let mut batches: Vec<RecordBatch> = Vec::new();
+    for batch in reader {
+        batches.push(batch?);
+    }
+
+    if batches.is_empty() {
+        writeln!(ctx.err, "No batches found in {BATCH_ITER_FILE}.")?;
+        return Ok(());
+    }
+
+    let pdf_text_idx = batches[0]
+        .schema()
+        .column_with_name("pdf_text")
+        .map(|(i, _)| i)
+        .ok_or_else(|| CLIError::ConfigError("No pdf_text column found in batch data".into()))?;
+
+    let texts: Vec<String> = batches
+        .iter()
+        .flat_map(|batch| {
+            arrow_array::cast::as_string_array(batch.column(pdf_text_idx))
+                .iter()
+                .filter_map(|s| s.map(str::to_owned))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let total = texts.len();
+    writeln!(ctx.out, "Submitting {total} texts to the batch embedding API...")?;
+
+    let embedding_config =
+        ctx.config
+            .get_embedding_config()
+            .ok_or(CLIError::ConfigError(
+                "Could not get embedding config".into(),
+            ))?;
+
+    let adapter = BatchProviderAdapter::from_embedding_config(&embedding_config)?;
+    let metadata = adapter.submit_texts(texts).await?;
+
+    writeln!(ctx.out, "Batch submitted successfully!")?;
+    writeln!(ctx.out, "  Batch ID : {}", metadata.batch_id)?;
+    writeln!(ctx.out, "  Provider : {}", metadata.provider)?;
+    writeln!(ctx.out, "  Texts    : {}", metadata.total_texts)?;
+    writeln!(ctx.out)?;
+    writeln!(ctx.out, "Check progress with '/batch status'.")?;
+    writeln!(
+        ctx.out,
+        "Once complete, run '/batch collect' to retrieve and store the embeddings."
+    )?;
+
+    let json = serde_json::to_string(&metadata)
+        .map_err(|e| CLIError::ConfigError(format!("Failed to serialize batch metadata: {e}")))?;
+    std::fs::write(BATCH_JOB_FILE, json)?;
+
+    Ok(())
+}
+
+/// Handle `/batch status [batch_id]` — report the current state of a batch job.
+///
+/// If `batch_id` is `None`, the ID is read from [`BATCH_JOB_FILE`].
+///
+/// # Errors
+///
+/// Returns a [`CLIError`] if the metadata file cannot be read, the API call fails, or writing
+/// output fails.
+pub(crate) async fn handle_batch_status_cmd<O: Write, E: Write>(
+    batch_id: Option<String>,
+    ctx: &mut Context<O, E>,
+) -> Result<(), CLIError> {
+    let (bid, provider) = if let Some(id) = batch_id {
+        (id, None)
+    } else {
+        let meta = read_batch_metadata()?;
+        (meta.batch_id, Some(meta.provider))
+    };
+
+    let embedding_config =
+        ctx.config
+            .get_embedding_config()
+            .ok_or(CLIError::ConfigError(
+                "Could not get embedding config".into(),
+            ))?;
+
+    let adapter = BatchProviderAdapter::from_embedding_config(&embedding_config)?;
+    let state = adapter.get_status(&bid).await?;
+
+    let status_str = match &state {
+        BatchJobState::Created => "Created (queued, not yet started)",
+        BatchJobState::InProgress => "In progress",
+        BatchJobState::Completed => "Completed",
+        BatchJobState::Failed => "Failed",
+        BatchJobState::Canceling => "Canceling",
+        BatchJobState::Canceled => "Canceled",
+        _ => "Unknown",
+    };
+
+    writeln!(ctx.out, "Batch ID : {bid}")?;
+    if let Some(prov) = provider {
+        writeln!(ctx.out, "Provider : {prov}")?;
+    }
+    writeln!(ctx.out, "Status   : {status_str}")?;
+
+    if matches!(state, BatchJobState::Completed) {
+        writeln!(ctx.out)?;
+        writeln!(
+            ctx.out,
+            "Batch complete! Run '/batch collect' to write the embeddings to the database."
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Handle `/batch collect [batch_id]` — download completed embeddings and write them to LanceDB.
+///
+/// If `batch_id` is `None`, the ID is read from [`BATCH_JOB_FILE`]. The command also requires
+/// `batch_iter.bin` to be present so it can attach the embeddings to the original text records.
+///
+/// On success, both [`BATCH_JOB_FILE`] and `batch_iter.bin` are deleted.
+///
+/// # Errors
+///
+/// Returns a [`CLIError`] if the batch is not yet complete, either state file is missing,
+/// the API call fails, building Arrow arrays fails, or the database write fails.
+pub(crate) async fn handle_batch_collect_cmd<O: Write, E: Write>(
+    batch_id: Option<String>,
+    ctx: &mut Context<O, E>,
+) -> Result<(), CLIError> {
+    let metadata = {
+        let mut m = read_batch_metadata()?;
+        if let Some(id) = batch_id {
+            m.batch_id = id;
+        }
+        m
+    };
+
+    let embedding_config =
+        ctx.config
+            .get_embedding_config()
+            .ok_or(CLIError::ConfigError(
+                "Could not get embedding config".into(),
+            ))?;
+
+    let adapter = BatchProviderAdapter::from_embedding_config(&embedding_config)?;
+
+    let state = adapter.get_status(&metadata.batch_id).await?;
+    if !matches!(state, BatchJobState::Completed) {
+        let status_str = match state {
+            BatchJobState::Created => "Created",
+            BatchJobState::InProgress => "InProgress",
+            BatchJobState::Failed => "Failed",
+            BatchJobState::Canceling => "Canceling",
+            BatchJobState::Canceled => "Canceled",
+            _ => "Unknown",
+        };
+        writeln!(
+            ctx.err,
+            "Batch '{}' is not yet complete (status: {status_str}). Try again later.",
+            metadata.batch_id
+        )?;
+        return Ok(());
+    }
+
+    writeln!(
+        ctx.out,
+        "Downloading embeddings for batch '{}'...",
+        metadata.batch_id
+    )?;
+    let embeddings = adapter.collect_embeddings(&metadata).await?;
+    writeln!(ctx.out, "Retrieved {} embeddings.", embeddings.len())?;
+
+    let file = File::open(BATCH_ITER_FILE).map_err(|_| {
+        CLIError::ConfigError(format!(
+            "Could not open {BATCH_ITER_FILE}. \
+             The file must still be present to attach the downloaded embeddings."
+        ))
+    })?;
+    let reader = FileReader::try_new(file, None)?;
+
+    let mut batches: Vec<RecordBatch> = Vec::new();
+    for batch in reader {
+        batches.push(batch?);
+    }
+
+    let embedding_dim = embedding_config.embedding_dims();
+
+    let mut offset = 0usize;
+    let mut new_batches = Vec::with_capacity(batches.len());
+    for batch in batches {
+        let n = batch.num_rows();
+        let batch_embeddings = embeddings.get(offset..offset + n).ok_or_else(|| {
+            CLIError::ConfigError("Embedding count does not match the number of batch rows".into())
+        })?;
+        offset += n;
+        new_batches.push(attach_embeddings(&batch, batch_embeddings, embedding_dim)?);
+    }
+
+    writeln!(ctx.out, "Writing embeddings to the database...")?;
+    ctx.store.upsert_precomputed_batches(new_batches).await?;
+
+    std::fs::remove_file(BATCH_ITER_FILE).ok();
+    std::fs::remove_file(BATCH_JOB_FILE).ok();
+
+    writeln!(ctx.out, "Successfully stored batch embeddings!")?;
+    writeln!(ctx.out, "Run '/index' to update the search indices.")?;
+
+    Ok(())
+}
+
+/// Read [`BatchJobMetadata`] from [`BATCH_JOB_FILE`].
+fn read_batch_metadata() -> Result<BatchJobMetadata, CLIError> {
+    let content = std::fs::read_to_string(BATCH_JOB_FILE).map_err(|_| {
+        CLIError::ConfigError(format!(
+            "Could not read {BATCH_JOB_FILE}. Run '/batch submit' first."
+        ))
+    })?;
+    serde_json::from_str(&content)
+        .map_err(|e| CLIError::ConfigError(format!("Failed to parse batch metadata: {e}")))
+}
+
+/// Append a pre-computed `embeddings` column to an Arrow [`RecordBatch`].
+fn attach_embeddings(
+    batch: &RecordBatch,
+    embeddings: &[Vec<f32>],
+    dim: usize,
+) -> Result<RecordBatch, CLIError> {
+    let dim_i32 = i32::try_from(dim)
+        .map_err(|_| CLIError::ConfigError(format!("Embedding dimension {dim} overflows i32")))?;
+    let flattened: Vec<f32> = embeddings.iter().flatten().copied().collect();
+    let values = Float32Array::from(flattened);
+    let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+    let embedding_col = FixedSizeListArray::try_new(
+        Arc::clone(&item_field),
+        dim_i32,
+        Arc::new(values),
+        None,
+    )?;
+
+    let embedding_field = Arc::new(Field::new(
+        "embeddings",
+        DataType::FixedSizeList(item_field, dim_i32),
+        false,
+    ));
+
+    let new_schema = Arc::new(Schema::new(
+        batch
+            .schema()
+            .fields()
+            .iter()
+            .cloned()
+            .chain(std::iter::once(embedding_field))
+            .collect::<Vec<_>>(),
+    ));
+
+    let mut columns: Vec<Arc<dyn arrow_array::Array>> = batch.columns().to_vec();
+    columns.push(Arc::new(embedding_col));
+
+    RecordBatch::try_new(new_schema, columns).map_err(Into::into)
+}

--- a/zqa/src/cli/handlers/cli.rs
+++ b/zqa/src/cli/handlers/cli.rs
@@ -128,6 +128,18 @@ where
     )?;
     writeln!(
         &mut ctx.out,
+        "/batch submit\tSubmit parsed texts to the provider batch API (reads batch_iter.bin)."
+    )?;
+    writeln!(
+        &mut ctx.out,
+        "/batch status\tCheck the status of the last submitted batch job."
+    )?;
+    writeln!(
+        &mut ctx.out,
+        "/batch collect\tDownload completed batch embeddings and write them to the database."
+    )?;
+    writeln!(
+        &mut ctx.out,
         "/search\t\tSearch for papers without summarizing them. Usage: /search <query>"
     )?;
     writeln!(

--- a/zqa/src/cli/handlers/mod.rs
+++ b/zqa/src/cli/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod batch;
 pub(crate) mod cli;
 pub(crate) mod conversation;
 pub(crate) mod documents;

--- a/zqa/src/store/lance.rs
+++ b/zqa/src/store/lance.rs
@@ -94,6 +94,25 @@ impl LanceZoteroStore {
             .map_err(Into::into)
     }
 
+    /// Upsert Arrow record batches that already contain pre-computed `embeddings` into the
+    /// LanceDB table.
+    ///
+    /// Unlike [`Self::upsert_batches`], this bypasses the embedding function and writes the
+    /// `embeddings` column directly. Use this when embeddings have been obtained via the batch API.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`CLIError`] if LanceDB insertion fails.
+    pub(crate) async fn upsert_precomputed_batches(
+        &self,
+        batches: Vec<RecordBatch>,
+    ) -> Result<(), CLIError> {
+        self.backend
+            .insert_precomputed_items(batches, Some(&[DbFields::LibraryKey.as_ref()]))
+            .await
+            .map_err(Into::into)
+    }
+
     /// Create or update retrieval indices for the LanceDB table.
     ///
     /// # Errors


### PR DESCRIPTION
Exposes the already-implemented VoyageAI batch API through three new CLI commands: `/batch submit`, `/batch status`, and `/batch collect`.

The adapter layer (`BatchProviderAdapter` enum in `zqa-rag`) mirrors the existing `EmbeddingProviderConfig` pattern so future batch providers only need a new enum variant and three method implementations.

Batch job state is persisted to `batch_job.json` so status/collect can run in a later CLI session after the provider-side job completes. Pre-computed embeddings are written to LanceDB via a new `insert_precomputed_items` path that bypasses the embedding function.

https://claude.ai/code/session_01UZcWxAZXQEB2KF5mNyagz6