### PR TITLE
feat: implement embedding batch creation in CLI

### DIFF
--- a/zqa-rag/src/embedding/common.rs
+++ b/zqa-rag/src/embedding/common.rs
@@ -152,6 +152,19 @@ impl EmbeddingProviderConfig {
             Self::ZeroEntropy(c) => &c.embedding_model,
         }
     }
+
+    /// Returns the embedding dimensions.
+    #[must_use]
+    pub fn dims(&self) -> usize {
+        match self {
+            Self::OpenAI(c) => c.embedding_dims,
+            Self::VoyageAI(c) => c.embedding_dims,
+            Self::Gemini(c) => c.embedding_dims,
+            Self::Cohere(c) => c.embedding_dims,
+            Self::Ollama(c) => c.embedding_dims,
+            Self::ZeroEntropy(c) => c.embedding_dims,
+        }
+    }
 }
 
 /// A trait intended to be used for responses from embedding provider APIs. Typically, these APIs

--- a/zqa-rag/src/llm/factory.rs
+++ b/zqa-rag/src/llm/factory.rs
@@ -2,12 +2,14 @@
 
 use std::sync::Arc;
 
+use crate::capabilities::BatchAPIProvider;
 use crate::clients::anthropic::AnthropicClient;
 use crate::clients::gemini::GeminiClient;
 use crate::clients::ollama::OllamaClient;
 use crate::clients::openai::OpenAIClient;
 use crate::clients::openrouter::OpenRouterClient;
 use crate::config::LLMClientConfig;
+use crate::embedding::common::{BatchEmbeddingRequest, BatchSubmission};
 use crate::embedding::voyage::VoyageAIClient;
 use crate::http_client::ReqwestClient;
 use crate::llm::base::{ApiClient, ChatRequest, ReasoningConfig};
@@ -112,4 +114,35 @@ pub fn get_client_with_config(config: &LLMClientConfig) -> Result<LLMClient, LLM
 pub enum BatchEmbeddingClient {
     /// Voyage AI batch embedding client
     VoyageAI(Arc<VoyageAIClient<ReqwestClient>>),
+}
+
+impl BatchEmbeddingClient {
+    /// Submit a request to the batch embedding API.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - A [`BatchEmbeddingRequest`] object containing all the texts.
+    ///
+    /// # Returns
+    ///
+    /// Details of the submitted batch if succeeded, or an [`LLMError`].
+    ///
+    /// # Errors
+    ///
+    /// * `LLMError::EnvError` - If the API key is not set, and no config is provided
+    /// * `LLMError::InvalidHeaderError` - If the API key cannot be parsed as a header value
+    /// * `LLMError::TimeoutError` - If the HTTP request times out
+    /// * `LLMError::CredentialError` - If the API returns 401 or 403
+    /// * `LLMError::HttpStatusError` - If the API returns another unsuccessful status code
+    /// * `LLMError::NetworkError` - If a network connectivity error occurs
+    /// * `LLMError::DeserializationError` - If either API response cannot be parsed
+    /// * `LLMError::GenericLLMError` - If the temporary JSONL file cannot be written
+    pub async fn submit_batch(
+        &self,
+        request: BatchEmbeddingRequest,
+    ) -> Result<BatchSubmission, LLMError> {
+        match self {
+            Self::VoyageAI(client) => client.submit_batch(request).await,
+        }
+    }
 }

--- a/zqa-rag/src/providers/provider_id.rs
+++ b/zqa-rag/src/providers/provider_id.rs
@@ -2,11 +2,14 @@
 
 use std::str::FromStr;
 
+use serde::{Deserialize, Serialize};
+
 use crate::capabilities::{EmbeddingProvider, ModelProvider, RerankerProvider};
 
 /// The canonical list of providers, regardless of capabilities. The
 /// [`super::registry::ProviderRegistry`] is responsible for maintaining that information.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ProviderId {

--- a/zqa/src/cli/app.rs
+++ b/zqa/src/cli/app.rs
@@ -5,6 +5,7 @@ use rustyline::error::ReadlineError;
 
 use crate::cli::commands::{Command, parse_command};
 use crate::cli::errors::CLIError;
+use crate::cli::handlers::batch::handle_batch_cmd;
 use crate::cli::handlers::cli::{
     handle_config_cmd, handle_help_cmd, handle_new_conversation_cmd, handle_quit_cmd,
 };
@@ -44,26 +45,27 @@ pub(crate) async fn dispatch_command<O: Write, E: Write>(
         parse_command(command.trim()).map_err(|e| CLIError::CommandError(e.to_string()))?;
 
     match command {
+        Command::Batch(subcmd) => handle_batch_cmd(subcmd, ctx).await,
+        Command::CheckHealth => handle_checkhealth_cmd(ctx).await,
+        Command::Config => handle_config_cmd(ctx),
+        Command::Dedup => handle_dedup_cmd(ctx).await,
+        Command::Docs(subcmd) => handle_docs_cmd(subcmd, ctx),
+        Command::Doctor => handle_doctor_cmd(ctx).await,
         Command::DoNothing => {
             return Ok(true);
         }
-        Command::Process => handle_process_cmd(ctx).await,
         Command::Embed { fix } => handle_embed_cmd(fix, ctx).await,
-        Command::Dedup => handle_dedup_cmd(ctx).await,
-        Command::Index => handle_index_cmd(ctx).await,
-        Command::Resume => handle_resume_cmd(ctx),
         Command::Help => handle_help_cmd(ctx),
+        Command::Index => handle_index_cmd(ctx).await,
+        Command::NewConversation => handle_new_conversation_cmd(ctx),
+        Command::Process => handle_process_cmd(ctx).await,
         Command::Quit => {
             return handle_quit_cmd(ctx).and(Ok(false));
         }
-        Command::CheckHealth => handle_checkhealth_cmd(ctx).await,
         Command::Query { text } => handle_query_cmd(text, ctx).await,
-        Command::Doctor => handle_doctor_cmd(ctx).await,
-        Command::NewConversation => handle_new_conversation_cmd(ctx),
-        Command::Config => handle_config_cmd(ctx),
-        Command::Stats => handle_stats_cmd(ctx).await,
+        Command::Resume => handle_resume_cmd(ctx),
         Command::Search { query } => handle_search_cmd(query, ctx).await,
-        Command::Docs(subcmd) => handle_docs_cmd(subcmd, ctx),
+        Command::Stats => handle_stats_cmd(ctx).await,
     }
     .and(Ok(true))
 }

--- a/zqa/src/cli/commands.rs
+++ b/zqa/src/cli/commands.rs
@@ -7,9 +7,11 @@ pub(crate) enum BatchCommand {
 }
 
 impl BatchCommand {
+    #[allow(dead_code)]
     pub(crate) const VARIANTS: &'static [Self] =
         &[Self::Create, Self::CheckStatus, Self::FetchResults];
 
+    #[allow(dead_code)]
     pub(crate) fn as_str(&self) -> &str {
         match self {
             Self::Create => "create",
@@ -27,7 +29,8 @@ impl BatchCommand {
         }
     }
 
-    fn variants() -> impl Iterator<Item = &'static str> {
+    #[allow(dead_code)]
+    pub(crate) fn variants() -> impl Iterator<Item = &'static str> {
         Self::VARIANTS.iter().map(Self::as_str)
     }
 }

--- a/zqa/src/cli/commands.rs
+++ b/zqa/src/cli/commands.rs
@@ -112,7 +112,7 @@ pub(crate) fn parse_command(command: &str) -> Result<Command, CommandParseError>
                 let subcmd = subcmd.trim();
                 let Ok(subcmd) = BatchCommand::from_str(subcmd) else {
                     return Err(CommandParseError::InvalidCommand(format!(
-                        "Invalid subcommand to /embed: {subcmd}"
+                        "Invalid subcommand to /batch: {subcmd}"
                     )));
                 };
 

--- a/zqa/src/cli/commands.rs
+++ b/zqa/src/cli/commands.rs
@@ -1,22 +1,55 @@
 use thiserror::Error;
 
+pub(crate) enum BatchCommand {
+    Create,
+    CheckStatus,
+    FetchResults,
+}
+
+impl BatchCommand {
+    pub(crate) const VARIANTS: &'static [Self] =
+        &[Self::Create, Self::CheckStatus, Self::FetchResults];
+
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            Self::Create => "create",
+            Self::CheckStatus => "check",
+            Self::FetchResults => "fetch",
+        }
+    }
+
+    pub(crate) fn from_str(s: &str) -> Result<Self, ()> {
+        match s {
+            "create" => Ok(Self::Create),
+            "check" => Ok(Self::CheckStatus),
+            "fetch" => Ok(Self::FetchResults),
+            _ => Err(()),
+        }
+    }
+
+    fn variants() -> impl Iterator<Item = &'static str> {
+        Self::VARIANTS.iter().map(Self::as_str)
+    }
+}
+
 pub(crate) enum Command {
-    Help,
+    Batch(BatchCommand),
     CheckHealth,
-    DoNothing,
-    Doctor,
-    Embed { fix: bool },
-    Process,
-    Index,
-    Stats,
-    Dedup,
-    Resume,
     Config,
-    NewConversation,
-    Quit,
+    Dedup,
     Docs(DocsCommand),
-    Search { query: String },
+    Doctor,
+    DoNothing,
+    Embed { fix: bool },
+    Help,
+    Index,
+    NewConversation,
+    Process,
     Query { text: String },
+    Quit,
+    Resume,
+    Search { query: String },
+    Stats,
 }
 
 pub(crate) enum DocsCommand {
@@ -34,19 +67,20 @@ pub(crate) enum CommandParseError {
 pub(crate) fn parse_command(command: &str) -> Result<Command, CommandParseError> {
     match command {
         "" => Ok(Command::DoNothing),
-        "/new" => Ok(Command::NewConversation),
-        "/help" | "help" | "?" => Ok(Command::Help),
         "/checkhealth" => Ok(Command::CheckHealth),
+        "/config" => Ok(Command::Config),
+        "/dedup" => Ok(Command::Dedup),
         "/doctor" => Ok(Command::Doctor),
         "/embed" => Ok(Command::Embed { fix: false }),
-        "/process" => Ok(Command::Process),
+        "/help" | "help" | "?" => Ok(Command::Help),
         "/index" => Ok(Command::Index),
-        "/stats" => Ok(Command::Stats),
-        "/dedup" => Ok(Command::Dedup),
+        "/new" => Ok(Command::NewConversation),
+        "/process" => Ok(Command::Process),
         "/resume" => Ok(Command::Resume),
-        "/config" => Ok(Command::Config),
+        "/stats" => Ok(Command::Stats),
         "/quit" | "/exit" | "quit" | "exit" => Ok(Command::Quit),
         query if query.starts_with('/') => {
+            // Handle commands that take subcommands
             if let Some(search_term) = query.strip_prefix("/search") {
                 let search_term = search_term.trim();
                 if search_term.is_empty() {
@@ -69,6 +103,17 @@ pub(crate) fn parse_command(command: &str) -> Result<Command, CommandParseError>
                 }
 
                 return Ok(Command::Embed { fix: true });
+            }
+
+            if let Some(subcmd) = query.strip_prefix("/batch") {
+                let subcmd = subcmd.trim();
+                let Ok(subcmd) = BatchCommand::from_str(subcmd) else {
+                    return Err(CommandParseError::InvalidCommand(format!(
+                        "Invalid subcommand to /embed: {subcmd}"
+                    )));
+                };
+
+                return Ok(Command::Batch(subcmd));
             }
 
             if let Some(subcmd) = query.strip_prefix("/docs") {

--- a/zqa/src/cli/errors.rs
+++ b/zqa/src/cli/errors.rs
@@ -21,8 +21,6 @@ pub enum CLIError {
     LLMError(String),
     #[error("Mutex poisoning error: {0}")]
     LockPoisoningError(String),
-    #[error("Malformed batch in batch_iter.bin")]
-    MalformedBatchError,
     #[error("Error from readline: {0}")]
     ReadlineError(String),
     #[error("Serialization error: {0}")]

--- a/zqa/src/cli/errors.rs
+++ b/zqa/src/cli/errors.rs
@@ -3,7 +3,7 @@ use std::{io, sync::PoisonError};
 use thiserror::Error;
 use zqa_rag::{llm::errors::LLMError, vector::backends::lance::LanceError};
 
-use crate::{config::ConfigError, utils};
+use crate::{config::ConfigError, state::StateError, utils};
 
 #[derive(Debug, Error)]
 pub enum CLIError {
@@ -11,20 +11,24 @@ pub enum CLIError {
     ArrowError(String),
     #[error("Command error: {0}")]
     CommandError(String),
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
     #[error("IO Error: {0}")]
     IOError(#[from] io::Error),
+    #[error("LanceDB error: {0}")]
+    LanceError(String),
     #[error("Error communicating with the LLM: {0}")]
     LLMError(String),
+    #[error("Mutex poisoning error: {0}")]
+    LockPoisoningError(String),
     #[error("Malformed batch in batch_iter.bin")]
     MalformedBatchError,
     #[error("Error from readline: {0}")]
     ReadlineError(String),
-    #[error("LanceDB error: {0}")]
-    LanceError(String),
-    #[error("Configuration error: {0}")]
-    ConfigError(String),
-    #[error("Mutex poisoning error: {0}")]
-    LockPoisoningError(String),
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+    #[error("Error accessing state directory: {0}")]
+    StateDirError(#[from] StateError),
 }
 
 impl From<ConfigError> for CLIError {

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -50,7 +50,11 @@
 //!
 //! For the structure of this file, see [`BatchEmbeddingMetadata`].
 
-use std::{fs, io::Write};
+use std::{
+    fs,
+    hash::{DefaultHasher, Hash, Hasher},
+    io::Write,
+};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -71,12 +75,13 @@ use crate::{state::get_state_dir, utils::library::parse_library};
 struct BatchEmbeddingMetadata {
     /// The batch ID
     batch_id: String,
+    /// The file ID from the provider's Files API
+    file_id: String,
     /// The batch embedding provider
     provider: ProviderId,
     /// The embedding model name
     model: String,
-    /// Date of creation, from the API (as opposed to local time). Used to give users context when
-    /// referring to a batch.
+    /// Date of creation (local time, in UTC). Used to give users context when referring to a batch.
     created_at: DateTime<Utc>,
     /// Hashes of each text in this batch. Since our texts can be quite large, and we only need
     /// equality tests, a hash is a simpler solution.
@@ -107,7 +112,7 @@ fn get_seq_id() -> Result<usize, CLIError> {
         return Ok(1);
     }
 
-    let mut entries = fs::read_dir(batch_dir)?
+    let mut entries = fs::read_dir(&batch_dir)?
         .filter_map(|entry| {
             let file_name = entry.ok()?.file_name().into_string().ok()?;
 
@@ -123,11 +128,16 @@ fn get_seq_id() -> Result<usize, CLIError> {
     }
 
     entries.sort();
-    let last_seq = entries.into_iter().rev().find_map(|f| {
-        // Ignore elements that don't parse to a valid integer.
-        let (_, seq_str) = f.split_at("batch_".len());
-        seq_str.parse::<usize>().ok()
-    });
+    let last_seq = fs::read_dir(batch_dir)?
+        .filter_map(|entry| {
+            let file_name = entry.ok()?.file_name().into_string().ok()?;
+            file_name
+                .strip_prefix("batch_")?
+                .strip_suffix(".log")?
+                .parse::<usize>()
+                .ok()
+        })
+        .max();
 
     last_seq.map_or_else(|| Ok(1), |val| Ok(val + 1))
 }
@@ -165,6 +175,7 @@ fn write_batch_metadata(
 
     let metadata = BatchEmbeddingMetadata {
         batch_id: submission.batch_id,
+        file_id: submission.file_id,
         provider,
         model,
         created_at: Utc::now(),
@@ -174,7 +185,7 @@ fn write_batch_metadata(
     };
 
     let seq = get_seq_id()?;
-    let filename = format!("batch_{seq}");
+    let filename = format!("batch_{seq}.log");
     let contents = serde_json::to_string_pretty(&metadata)?;
     fs::write(batch_dir.join(filename), contents)?;
 
@@ -199,7 +210,8 @@ where
 
     let cfg = ctx.config.get_embedding_config();
     let Some(cfg) = cfg else {
-        return Err(CLIError::ConfigError(
+        // `CommandError` variants don't exit the CLI
+        return Err(CLIError::CommandError(
             concat!(
                 "Could not get a config for batch embeddings. Ensure your config has an ",
                 "embedding provider configured. See https://github.com/zotero-rag/zotero-rag#configuration ",
@@ -217,6 +229,16 @@ where
         Ok(embedder) => embedder,
     };
 
+    let hashes = new_items
+        .iter()
+        .map(|item| {
+            let mut hasher = DefaultHasher::new();
+            item.text.hash(&mut hasher);
+
+            hasher.finish().to_string()
+        })
+        .collect::<Vec<_>>();
+
     let request = BatchEmbeddingRequest {
         model: cfg.model_name().into(),
         dims: cfg.dims(),
@@ -230,12 +252,16 @@ where
     };
 
     let submission = embedder.submit_batch(request).await?;
+    let batch_id = submission.batch_id.clone();
     write_batch_metadata(
         cfg.provider_id(),
         cfg.model_name().into(),
-        vec![],
+        hashes,
         submission,
-    )
+    )?;
+
+    writeln!(ctx.out, "Batch {batch_id} successfully created.")?;
+    Ok(())
 }
 
 /// Handle the `/batch` commands.

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -1,0 +1,94 @@
+//! Command handlers for `/batch` commands.
+//!
+//! The philosophy here is that a user shouldn't have to care about how this works. As far as they
+//! are concerned, this should "just work" (within reason). Our protocol is as follows:
+//!
+//! * Users can dispatch multiple `/batch` commands at once (i.e., while others are being processed
+//!   by the provider).
+//!   * In such cases, we ask ONCE that they intended to do this, and report the overlap size. At
+//!     this point, they can either process only the new ones in this batch, or ask to process the
+//!     entire thing anyway. In the latter case, we also give them an option to *replace* the
+//!     previous batch, but *only* if the former batch is a proper subset of this one. If this is
+//!     affirmative, we send a cancellation request to the provider and delete the old file.
+//!   * We should always, when asking for such confirmations, also flag if that batch's
+//!     provider/model ID are different from the currently-used one. This is actually a bigger
+//!     problem since the DB shouldn't contain embeddings from different providers in the first place.
+//! * The entire abstraction for a batch submission is a file placed in the user's state dir (see
+//!   [`crate::state`] for an implementation). This means:
+//!   * A file existing, and being valid (in its contents) implies that that batch exists. Whether
+//!     it *actually* exists or is invalid data (e.g., it contains a batch ID that doesn't exist) is
+//!     not guaranteed.
+//!   * A file *not* existing means that as far as we are concerned, that batch wasn't dispatched by
+//!     us; not our circus, not our monkeys.
+//!   * The origin of the file is irrelevant. Users are free to create a file in that directory, and
+//!     we will treat it as valid if the structure is right.
+//!   * Files are named `batch_<id>.log`, where `id` are sequence numbers to avoid dealing with
+//!     clock drift ([`std::time::SystemTime`] is a fun read for the uninitiated).
+//! * We check the status of batches on startup and when the user explicitly requests it.
+//! * When we check the status of a batch:
+//!   * If on startup, checking the status reveals a state that is not "submitted" (or that
+//!     provider's lifecycle equivalent), we notify the user, and they decide how to proceed. This
+//!     includes a response indicating that the batch doesn't exist.
+//!   * If the batch has completely failed and there are no successes, we prompt the user to try again.
+//!   * If the batch has partially succeeded, we notify the user and let them decide. The default
+//!     option here should be to add the processed results to our backend and retry the remaining.
+//!     The user should also have the option to just ignore and retry the whole thing, or pick the
+//!     successes and drop the rest.
+//!   * If the batch has completely succeeded, we notify the user only if this check was initiated
+//!     at startup (as opposed to by user request). We add these to our backend and remove this batch.
+//! * Broadly, our semantics resemble a write-ahead log. The files are sorted by creation time, and
+//!   we scan a cache when inserting a batch into the backend to check conflicts (and the newest
+//!   one wins). Moreover, we maintain a cache of hashes (try saying that thrice quickly) with the
+//!   following semantics:
+//!   * This file is shared across batches.
+//!   * The file contains a map from text hashes to corresponding provider ID, provider model, and
+//!     the sequence number of the (newest) batch it belonged to.
+//!   * Before writing to the DB, we filter out items that match the hash, provider, and provider
+//!     model.
+//!   * After writing to the DB, we add the hashes of the texts added to this cache along with that
+//!     same auxiliary information.
+//!
+//! For the structure of this file, see [`BatchEmbeddingMetadata`].
+
+use std::io::Write;
+
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+use zqa_rag::providers::ProviderId;
+
+use crate::{
+    cli::{commands::BatchCommand, errors::CLIError},
+    common::Context,
+};
+
+/// Metadata about a batch embedding request. This is the file structure used to represent a batch
+/// in progress.
+#[derive(Debug, Serialize, Deserialize)]
+struct BatchEmbeddingMetadata {
+    /// The batch ID
+    batch_id: String,
+    /// The batch embedding provider
+    provider: ProviderId,
+    /// Date of creation, from the API (as opposed to local time). Used to give users context when
+    /// referring to a batch.
+    created_at: NaiveDate,
+    /// Hashes of each text in this batch. Since our texts can be quite large, and we only need
+    /// equality tests, a hash is a simpler solution.
+    hashes: Vec<String>,
+    /// Optional indices to the hashes above if we know this information (by checking).
+    succeeded: Option<Vec<usize>>,
+    /// Optional indices to the hashes above if we know this information (by checking).
+    failed: Option<Vec<usize>>,
+}
+
+/// Handle the `/batch` commands.
+pub(crate) async fn handle_batch_cmd<O, E>(
+    _subcmd: BatchCommand,
+    _ctx: &mut Context<O, E>,
+) -> Result<(), CLIError>
+where
+    O: Write,
+    E: Write,
+{
+    Ok(())
+}

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -112,22 +112,6 @@ fn get_seq_id() -> Result<usize, CLIError> {
         return Ok(1);
     }
 
-    let mut entries = fs::read_dir(&batch_dir)?
-        .filter_map(|entry| {
-            let file_name = entry.ok()?.file_name().into_string().ok()?;
-
-            if file_name.starts_with("batch_") {
-                return Some(file_name);
-            }
-            None
-        })
-        .collect::<Vec<_>>();
-
-    if entries.is_empty() {
-        return Ok(1);
-    }
-
-    entries.sort();
     let last_seq = fs::read_dir(batch_dir)?
         .filter_map(|entry| {
             let file_name = entry.ok()?.file_name().into_string().ok()?;
@@ -224,7 +208,7 @@ where
     let registry = provider_registry();
     let embedder = match registry.create_batch_embedding(&cfg) {
         Err(e) => {
-            return Err(CLIError::ConfigError(e.to_string()));
+            return Err(CLIError::CommandError(e.to_string()));
         }
         Ok(embedder) => embedder,
     };
@@ -320,9 +304,9 @@ mod tests {
         let tmp = tempdir().unwrap();
         let batch_dir = tmp.path().join("batches");
         fs::create_dir_all(&batch_dir).unwrap();
-        fs::write(batch_dir.join("batch_1"), "").unwrap();
-        fs::write(batch_dir.join("batch_2"), "").unwrap();
-        fs::write(batch_dir.join("batch_3"), "").unwrap();
+        fs::write(batch_dir.join("batch_1.log"), "").unwrap();
+        fs::write(batch_dir.join("batch_2.log"), "").unwrap();
+        fs::write(batch_dir.join("batch_3.log"), "").unwrap();
 
         temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
             assert_eq!(get_seq_id().unwrap(), 4);
@@ -347,9 +331,9 @@ mod tests {
         let tmp = tempdir().unwrap();
         let batch_dir = tmp.path().join("batches");
         fs::create_dir_all(&batch_dir).unwrap();
-        fs::write(batch_dir.join("batch_1"), "").unwrap();
-        // "batch_abc" has a non-numeric suffix and should be silently skipped
-        fs::write(batch_dir.join("batch_abc"), "").unwrap();
+        fs::write(batch_dir.join("batch_1.log"), "").unwrap();
+        // "batch_abc.log" has a non-numeric suffix and should be silently skipped
+        fs::write(batch_dir.join("batch_abc.log"), "").unwrap();
 
         temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
             assert_eq!(get_seq_id().unwrap(), 2);
@@ -426,8 +410,8 @@ mod tests {
             .unwrap();
 
             let batch_dir = tmp.path().join("batches");
-            assert!(batch_dir.join("batch_1").exists());
-            assert!(batch_dir.join("batch_2").exists());
+            assert!(batch_dir.join("batch_1.log").exists());
+            assert!(batch_dir.join("batch_2.log").exists());
         });
     }
 }

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -14,7 +14,7 @@
 //!     provider/model ID are different from the currently-used one. This is actually a bigger
 //!     problem since the DB shouldn't contain embeddings from different providers in the first place.
 //! * The entire abstraction for a batch submission is a file placed in the user's state dir (see
-//!   [`crate::state`] for an implementation). This means:
+//!   [`crate::state`] for an implementation), in a `batches` subdirectory. This means:
 //!   * A file existing, and being valid (in its contents) implies that that batch exists. Whether
 //!     it *actually* exists or is invalid data (e.g., it contains a batch ID that doesn't exist) is
 //!     not guaranteed.
@@ -22,7 +22,7 @@
 //!     us; not our circus, not our monkeys.
 //!   * The origin of the file is irrelevant. Users are free to create a file in that directory, and
 //!     we will treat it as valid if the structure is right.
-//!   * Files are named `batch_<id>.log`, where `id` are sequence numbers to avoid dealing with
+//!   * Files are named `batch_<id>.log`, where `id` are (1-based) sequence numbers to avoid dealing with
 //!     clock drift ([`std::time::SystemTime`] is a fun read for the uninitiated).
 //! * We check the status of batches on startup and when the user explicitly requests it.
 //! * When we check the status of a batch:
@@ -35,7 +35,7 @@
 //!     The user should also have the option to just ignore and retry the whole thing, or pick the
 //!     successes and drop the rest.
 //!   * If the batch has completely succeeded, we notify the user only if this check was initiated
-//!     at startup (as opposed to by user request). We add these to our backend and remove this batch.
+//!     at startup. We add these to our backend and remove this batch.
 //! * Broadly, our semantics resemble a write-ahead log. The files are sorted by creation time, and
 //!   we scan a cache when inserting a batch into the backend to check conflicts (and the newest
 //!   one wins). Moreover, we maintain a cache of hashes (try saying that thrice quickly) with the
@@ -50,16 +50,20 @@
 //!
 //! For the structure of this file, see [`BatchEmbeddingMetadata`].
 
-use std::io::Write;
+use std::{fs, io::Write};
 
-use chrono::NaiveDate;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use zqa_rag::providers::ProviderId;
+use zqa_rag::{
+    embedding::common::{BatchEmbeddingInput, BatchEmbeddingRequest, BatchSubmission},
+    providers::{ProviderId, registry::provider_registry},
+};
 
 use crate::{
     cli::{commands::BatchCommand, errors::CLIError},
     common::Context,
 };
+use crate::{state::get_state_dir, utils::library::parse_library};
 
 /// Metadata about a batch embedding request. This is the file structure used to represent a batch
 /// in progress.
@@ -69,9 +73,11 @@ struct BatchEmbeddingMetadata {
     batch_id: String,
     /// The batch embedding provider
     provider: ProviderId,
+    /// The embedding model name
+    model: String,
     /// Date of creation, from the API (as opposed to local time). Used to give users context when
     /// referring to a batch.
-    created_at: NaiveDate,
+    created_at: DateTime<Utc>,
     /// Hashes of each text in this batch. Since our texts can be quite large, and we only need
     /// equality tests, a hash is a simpler solution.
     hashes: Vec<String>,
@@ -81,14 +87,321 @@ struct BatchEmbeddingMetadata {
     failed: Option<Vec<usize>>,
 }
 
+/// Gets the next available sequence number among the batch files in the state directory.
+///
+/// # Returns
+///
+/// The next available sequence number
+///
+/// # Errors
+///
+/// * `CLIError::StateDirError` if the user's base directory could not be obtained. See
+///   `directories::BaseDirError` for when this can occur.
+/// * `CLIError::IOError` if writing to the state directory failed. This is typically caused
+///   by permission issues.
+fn get_seq_id() -> Result<usize, CLIError> {
+    let batch_dir = get_state_dir()?.join("batches");
+    if !batch_dir.exists() {
+        // If it doesn't exist, we start at 1. This also eliminates this cause of an `Err` result
+        // from [`std::fs::read_dir`].
+        return Ok(1);
+    }
+
+    let mut entries = fs::read_dir(batch_dir)?
+        .filter_map(|entry| {
+            let file_name = entry.ok()?.file_name().into_string().ok()?;
+
+            if file_name.starts_with("batch_") {
+                return Some(file_name);
+            }
+            None
+        })
+        .collect::<Vec<_>>();
+
+    if entries.is_empty() {
+        return Ok(1);
+    }
+
+    entries.sort();
+    let last_seq = entries.into_iter().rev().find_map(|f| {
+        // Ignore elements that don't parse to a valid integer.
+        let (_, seq_str) = f.split_at("batch_".len());
+        seq_str.parse::<usize>().ok()
+    });
+
+    last_seq.map_or_else(|| Ok(1), |val| Ok(val + 1))
+}
+
+/// Write out metadata for a *new* batch.
+///
+/// This creates a new 1-indexed batch file in the state dir and writes out a
+/// [`BatchEmbeddingMetadata`] object.
+///
+/// # Arguments
+///
+/// * `provider` - The provider of the embedding model
+/// * `model` - The embedding model string
+/// * `hashes` - Hashes for the texts in this batch
+/// * `submission` - The result of a `submit_batch` on a batch embedding provider
+///
+/// # Errors
+///
+/// * `CLIError::StateDirError` if the user's base directory could not be obtained. See
+///   `directories::BaseDirError` for when this can occur.
+/// * `CLIError::IOError` in the following cases:
+///     * writing to the state directory failed. This is typically caused by permission issues.
+///     * writing out the serialized data failed
+/// * `CLIError::SerializationError` if JSON serialization failed.
+fn write_batch_metadata(
+    provider: ProviderId,
+    model: String,
+    hashes: Vec<String>,
+    submission: BatchSubmission,
+) -> Result<(), CLIError> {
+    let batch_dir = get_state_dir()?.join("batches");
+    if !batch_dir.exists() {
+        fs::create_dir_all(&batch_dir)?;
+    }
+
+    let metadata = BatchEmbeddingMetadata {
+        batch_id: submission.batch_id,
+        provider,
+        model,
+        created_at: Utc::now(),
+        hashes,
+        succeeded: None,
+        failed: None,
+    };
+
+    let seq = get_seq_id()?;
+    let filename = format!("batch_{seq}");
+    let contents = serde_json::to_string_pretty(&metadata)?;
+    fs::write(batch_dir.join(filename), contents)?;
+
+    Ok(())
+}
+
+async fn handle_batch_create_cmd<O, E>(ctx: &mut Context<O, E>) -> Result<(), CLIError>
+where
+    O: Write,
+    E: Write,
+{
+    let new_items = match parse_library(&ctx.store, None, None).await {
+        Ok(items) => items,
+        Err(parse_err) => {
+            writeln!(
+                &mut ctx.err,
+                "Could not parse library metadata: {parse_err}"
+            )?;
+            return Ok(());
+        }
+    };
+
+    let cfg = ctx.config.get_embedding_config();
+    let Some(cfg) = cfg else {
+        return Err(CLIError::ConfigError(
+            concat!(
+                "Could not get a config for batch embeddings. Ensure your config has an ",
+                "embedding provider configured. See https://github.com/zotero-rag/zotero-rag#configuration ",
+                "for configuration instructions."
+            )
+            .into(),
+        ))?;
+    };
+
+    let registry = provider_registry();
+    let embedder = match registry.create_batch_embedding(&cfg) {
+        Err(e) => {
+            return Err(CLIError::ConfigError(e.to_string()));
+        }
+        Ok(embedder) => embedder,
+    };
+
+    let request = BatchEmbeddingRequest {
+        model: cfg.model_name().into(),
+        dims: cfg.dims(),
+        inputs: new_items
+            .into_iter()
+            .map(|item| BatchEmbeddingInput {
+                id: item.metadata.library_key,
+                text: item.text,
+            })
+            .collect(),
+    };
+
+    let submission = embedder.submit_batch(request).await?;
+    write_batch_metadata(
+        cfg.provider_id(),
+        cfg.model_name().into(),
+        vec![],
+        submission,
+    )
+}
+
 /// Handle the `/batch` commands.
 pub(crate) async fn handle_batch_cmd<O, E>(
-    _subcmd: BatchCommand,
-    _ctx: &mut Context<O, E>,
+    subcmd: BatchCommand,
+    ctx: &mut Context<O, E>,
 ) -> Result<(), CLIError>
 where
     O: Write,
     E: Write,
 {
-    Ok(())
+    match subcmd {
+        BatchCommand::Create => handle_batch_create_cmd(ctx).await,
+        BatchCommand::CheckStatus => todo!(),
+        BatchCommand::FetchResults => todo!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+    use zqa_rag::{embedding::common::BatchSubmission, providers::ProviderId};
+
+    use super::{BatchEmbeddingMetadata, get_seq_id, write_batch_metadata};
+
+    fn make_submission(batch_id: &str) -> BatchSubmission {
+        BatchSubmission {
+            batch_id: batch_id.into(),
+            file_id: "file-id".into(),
+        }
+    }
+
+    #[test]
+    fn get_seq_id_returns_one_when_batch_dir_absent() {
+        let tmp = tempdir().unwrap();
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            assert_eq!(get_seq_id().unwrap(), 1);
+        });
+    }
+
+    #[test]
+    fn get_seq_id_returns_one_for_empty_dir() {
+        let tmp = tempdir().unwrap();
+        let batch_dir = tmp.path().join("batches");
+        fs::create_dir_all(&batch_dir).unwrap();
+
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            assert_eq!(get_seq_id().unwrap(), 1);
+        });
+    }
+
+    #[test]
+    fn get_seq_id_returns_next_after_existing_files() {
+        let tmp = tempdir().unwrap();
+        let batch_dir = tmp.path().join("batches");
+        fs::create_dir_all(&batch_dir).unwrap();
+        fs::write(batch_dir.join("batch_1"), "").unwrap();
+        fs::write(batch_dir.join("batch_2"), "").unwrap();
+        fs::write(batch_dir.join("batch_3"), "").unwrap();
+
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            assert_eq!(get_seq_id().unwrap(), 4);
+        });
+    }
+
+    #[test]
+    fn get_seq_id_ignores_non_batch_files() {
+        let tmp = tempdir().unwrap();
+        let batch_dir = tmp.path().join("batches");
+        fs::create_dir_all(&batch_dir).unwrap();
+        fs::write(batch_dir.join("other_file"), "").unwrap();
+        fs::write(batch_dir.join("cache.bin"), "").unwrap();
+
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            assert_eq!(get_seq_id().unwrap(), 1);
+        });
+    }
+
+    #[test]
+    fn get_seq_id_ignores_non_numeric_batch_suffixes() {
+        let tmp = tempdir().unwrap();
+        let batch_dir = tmp.path().join("batches");
+        fs::create_dir_all(&batch_dir).unwrap();
+        fs::write(batch_dir.join("batch_1"), "").unwrap();
+        // "batch_abc" has a non-numeric suffix and should be silently skipped
+        fs::write(batch_dir.join("batch_abc"), "").unwrap();
+
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            assert_eq!(get_seq_id().unwrap(), 2);
+        });
+    }
+
+    #[test]
+    fn write_batch_metadata_creates_batches_dir() {
+        let tmp = tempdir().unwrap();
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            write_batch_metadata(
+                ProviderId::VoyageAI,
+                "voyage-3".into(),
+                vec![],
+                make_submission("batch-abc"),
+            )
+            .unwrap();
+
+            assert!(tmp.path().join("batches").exists());
+        });
+    }
+
+    #[test]
+    fn write_batch_metadata_stores_correct_fields() {
+        let tmp = tempdir().unwrap();
+        let hashes = vec!["hash-a".to_string(), "hash-b".to_string()];
+
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            write_batch_metadata(
+                ProviderId::VoyageAI,
+                "voyage-3".into(),
+                hashes.clone(),
+                make_submission("my-batch-id"),
+            )
+            .unwrap();
+
+            let batch_dir = tmp.path().join("batches");
+            let files: Vec<_> = fs::read_dir(&batch_dir)
+                .unwrap()
+                .filter_map(std::result::Result::ok)
+                .collect();
+            assert_eq!(files.len(), 1);
+
+            let content = fs::read_to_string(files[0].path()).unwrap();
+            let meta: BatchEmbeddingMetadata = serde_json::from_str(&content).unwrap();
+
+            assert_eq!(meta.batch_id, "my-batch-id");
+            assert_eq!(meta.provider, ProviderId::VoyageAI);
+            assert_eq!(meta.model, "voyage-3");
+            assert_eq!(meta.hashes, hashes);
+            assert!(meta.succeeded.is_none());
+            assert!(meta.failed.is_none());
+        });
+    }
+
+    #[test]
+    fn write_batch_metadata_increments_sequence_number() {
+        let tmp = tempdir().unwrap();
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            write_batch_metadata(
+                ProviderId::VoyageAI,
+                "voyage-3".into(),
+                vec![],
+                make_submission("batch-1"),
+            )
+            .unwrap();
+
+            write_batch_metadata(
+                ProviderId::VoyageAI,
+                "voyage-3".into(),
+                vec![],
+                make_submission("batch-2"),
+            )
+            .unwrap();
+
+            let batch_dir = tmp.path().join("batches");
+            assert!(batch_dir.join("batch_1").exists());
+            assert!(batch_dir.join("batch_2").exists());
+        });
+    }
 }

--- a/zqa/src/cli/handlers/mod.rs
+++ b/zqa/src/cli/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod batch;
 pub(crate) mod cli;
 pub(crate) mod conversation;
 pub(crate) mod documents;

--- a/zqa/src/state.rs
+++ b/zqa/src/state.rs
@@ -24,7 +24,7 @@ const RESET: &str = "\x1b[0m";
 
 /// Errors that can occur when interacting with the state directory.
 #[derive(PartialEq, Debug, Error)]
-pub(crate) enum StateError {
+pub enum StateError {
     #[error("Failed to get home directory.")]
     DirectoryError,
     #[error("Failed to save first run information.")]


### PR DESCRIPTION
This is the second in a set of PRs to implement ZOT-127 (add batch API support to the CLI). The goal of this PR is not to complete that implementation, but only implement creation. More importantly, this PR specifies the semantics of the CLI's batch API.

PR reviewers: you should *not* critique the todo! implementations; but you *should* verify if the protocol specified in zqa/src/cli/handlers/batch.rs is sane.
