### PR TITLE
feat: implement basic version of batch fetch command

### DIFF
--- a/zqa-rag/src/llm/factory.rs
+++ b/zqa-rag/src/llm/factory.rs
@@ -9,7 +9,7 @@ use crate::clients::ollama::OllamaClient;
 use crate::clients::openai::OpenAIClient;
 use crate::clients::openrouter::OpenRouterClient;
 use crate::config::LLMClientConfig;
-use crate::embedding::common::{BatchEmbeddingRequest, BatchSubmission};
+use crate::embedding::common::{BatchEmbeddingRequest, BatchEmbeddingResults, BatchSubmission};
 use crate::embedding::voyage::VoyageAIClient;
 use crate::http_client::ReqwestClient;
 use crate::llm::base::{ApiClient, ChatRequest, ReasoningConfig};
@@ -168,6 +168,33 @@ impl BatchEmbeddingClient {
     pub async fn check_batch_status(&self, batch_id: &str) -> Result<BatchJobState, LLMError> {
         match self {
             Self::VoyageAI(client) => client.get_batch_status(batch_id).await,
+        }
+    }
+
+    /// Attempt to fetch the results of a submitted batch job.
+    ///
+    /// # Arguments
+    ///
+    /// * `batch_id` - The ID of the submitted batch, returned by the provider during submission.
+    ///
+    /// # Returns
+    ///
+    /// The results of the batch, including successes and failures.
+    ///
+    /// # Errors
+    ///
+    /// * `LLMError::BatchNotCompleted` - If the batch has not yet reached [`BatchJobState::Completed`] or [`BatchJobState::Failed`]
+    /// * `LLMError::EnvError` - If an API key is not set up
+    /// * `LLMError::InvalidHeaderError` - If the API key cannot be parsed as a header value
+    /// * `LLMError::TimeoutError` - If the HTTP request times out
+    /// * `LLMError::CredentialError` - If the API returns 401 or 403
+    /// * `LLMError::HttpStatusError` - If the API returns another unsuccessful status code
+    /// * `LLMError::NetworkError` - If a network connectivity error occurs
+    /// * `LLMError::DeserializationError` - If the response cannot be parsed
+    /// * `LLMError::GenericLLMError` - If a temporary file cannot be written
+    pub async fn fetch_results(&self, batch_id: &str) -> Result<BatchEmbeddingResults, LLMError> {
+        match self {
+            Self::VoyageAI(client) => client.get_batch_results(batch_id).await,
         }
     }
 }

--- a/zqa/src/cli/commands.rs
+++ b/zqa/src/cli/commands.rs
@@ -3,20 +3,17 @@ use thiserror::Error;
 pub(crate) enum BatchCommand {
     Create,
     CheckStatus,
-    FetchResults,
 }
 
 impl BatchCommand {
     #[allow(dead_code)]
-    pub(crate) const VARIANTS: &'static [Self] =
-        &[Self::Create, Self::CheckStatus, Self::FetchResults];
+    pub(crate) const VARIANTS: &'static [Self] = &[Self::Create, Self::CheckStatus];
 
     #[allow(dead_code)]
     pub(crate) fn as_str(&self) -> &str {
         match self {
             Self::Create => "create",
             Self::CheckStatus => "check",
-            Self::FetchResults => "fetch",
         }
     }
 
@@ -24,7 +21,6 @@ impl BatchCommand {
         match s {
             "create" => Ok(Self::Create),
             "check" => Ok(Self::CheckStatus),
-            "fetch" => Ok(Self::FetchResults),
             _ => Err(()),
         }
     }

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -323,6 +323,15 @@ where
         })
         .collect::<Vec<_>>();
 
+    if to_insert.is_empty() {
+        writeln!(
+            &mut ctx.out,
+            "All items in the batch were duplicates; no action taken.",
+        )?;
+
+        return Ok(());
+    }
+
     writeln!(
         &mut ctx.out,
         "{} items to insert, {} items dropped as duplicates.",
@@ -330,6 +339,32 @@ where
         batch.items.len() - to_insert.len()
     )?;
 
+    // Partition cache items to separate those whose sequence ID needs to be updated
+    let (mut overwriteable, rest): (HashMap<_, _>, HashMap<_, _>) =
+        cache.into_iter().partition(|(k, v)| {
+            batch.items.iter().any(|i| i.hash == *k)
+                && v.provider_id == batch.provider
+                && v.model == batch.model
+                && v.seq_id < batch.seq_id
+        });
+
+    // For the matches, update the batch seq number
+    overwriteable.iter_mut().for_each(|(_, v)| {
+        v.seq_id = batch.seq_id;
+    });
+
+    overwriteable.extend(rest);
+
+    // Add the batch's new items to the set of cache entries to update
+    for (item, _) in &to_insert {
+        overwriteable.entry(item.hash).or_insert(CacheEntry {
+            provider_id: batch.provider,
+            model: batch.model.clone(),
+            seq_id: batch.seq_id,
+        });
+    }
+
+    // Build batch to insert into the LanceDB store
     let library_keys: Vec<&str> = to_insert
         .iter()
         .map(|(i, _)| i.library_key.as_str())
@@ -362,25 +397,16 @@ where
             &embedding_config,
         )?])
         .await?;
+    ctx.store.create_or_update_indices().await?;
 
-    let (mut overwriteable, rest): (HashMap<_, _>, HashMap<_, _>) =
-        cache.into_iter().partition(|(k, v)| {
-            batch.items.iter().any(|i| i.hash == *k)
-                && v.provider_id == batch.provider
-                && v.model == batch.model
-                && v.seq_id < batch.seq_id
-        });
-
-    // For the matches, update the batch seq number
-    overwriteable.iter_mut().for_each(|(_, v)| {
-        v.seq_id = batch.seq_id;
-    });
-
-    overwriteable.extend(rest);
     cache_file.seek(SeekFrom::Start(0))?;
     cache_file.set_len(0)?;
     cache_file.write_all(serde_json::to_string_pretty(&overwriteable)?.as_bytes())?;
     cache_file.unlock()?;
+
+    if results.failed.is_empty() {
+        fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
+    }
 
     Ok(())
 }

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -53,6 +53,8 @@
 //!
 //! For the structure of this file, see [`BatchEmbeddingMetadata`].
 
+use std::collections::HashSet;
+use std::io::Seek;
 use std::{
     collections::HashMap,
     fmt::Display,
@@ -94,6 +96,7 @@ struct BatchItem {
 
 impl From<ZoteroItem> for BatchItem {
     fn from(value: ZoteroItem) -> Self {
+        // TODO: Replace DefaultHasher with a stable algorithm (e.g. xxhash or sha2)
         let mut hasher = DefaultHasher::new();
         hasher.write(value.text.as_bytes());
 
@@ -125,9 +128,9 @@ struct BatchEmbeddingMetadata {
     created_at: DateTime<Utc>,
     /// Items in this batch
     items: Vec<BatchItem>,
-    /// Optional indices to the hashes above if we know this information (by checking).
+    /// Optional indices to the items above if we know this information (by checking).
     succeeded: Option<Vec<usize>>,
-    /// Optional indices to the hashes above if we know this information (by checking).
+    /// Optional indices to the items above if we know this information (by checking).
     failed: Option<Vec<usize>>,
 }
 
@@ -282,9 +285,9 @@ where
         .map(|i| (i.library_key.as_str(), i)) // we use `library_key` as the id in the batch
         .collect::<HashMap<&str, &BatchItem>>();
 
-    let items_to_embeddings: Vec<(&BatchItem, Vec<f32>)> = results.succeeded.iter().filter_map(|res| {
+    let items_to_embeddings: Vec<(&BatchItem, Vec<f32>)> = results.succeeded.into_iter().filter_map(|res| {
         if let Some(item) = ids_to_items.get(res.id.as_str()) {
-            Some((*item, res.embedding.clone()))
+            Some((*item, res.embedding))
         } else {
             writeln!(&mut ctx.err,
                 "Item {} from batch response not in library. If you removed items from your library, this is fine.",
@@ -303,7 +306,7 @@ where
         .read(true)
         .write(true)
         .create(true)
-        .truncate(true)
+        .truncate(false)
         .open(batch_dir.join(".hash_cache"))?;
 
     cache_file.lock()?;
@@ -328,6 +331,7 @@ where
         .collect::<Vec<_>>();
 
     if to_insert.is_empty() {
+        // TODO: this can result in a "zombie" batch, need to handle
         writeln!(
             &mut ctx.out,
             "All items in the batch were duplicates; no action taken.",
@@ -343,10 +347,12 @@ where
         batch.items.len() - to_insert.len()
     )?;
 
+    let item_hashes: HashSet<u64> = batch.items.iter().map(|i| i.hash).collect();
+
     // Partition cache items to separate those whose sequence ID needs to be updated
     let (mut overwriteable, rest): (HashMap<_, _>, HashMap<_, _>) =
         cache.into_iter().partition(|(k, v)| {
-            batch.items.iter().any(|i| i.hash == *k)
+            item_hashes.contains(k)
                 && v.provider_id == batch.provider
                 && v.model == batch.model
                 && v.seq_id < batch.seq_id
@@ -361,11 +367,14 @@ where
 
     // Add the batch's new items to the set of cache entries to update
     for (item, _) in &to_insert {
-        overwriteable.entry(item.hash).or_insert(CacheEntry {
-            provider_id: batch.provider,
-            model: batch.model.clone(),
-            seq_id: batch.seq_id,
-        });
+        overwriteable.insert(
+            item.hash,
+            CacheEntry {
+                provider_id: batch.provider,
+                model: batch.model.clone(),
+                seq_id: batch.seq_id,
+            },
+        );
     }
 
     // Build batch to insert into the LanceDB store
@@ -403,7 +412,9 @@ where
         .await?;
     ctx.store.create_or_update_indices().await?;
 
-    // We already set `.truncate(true)`
+    cache_file.seek(io::SeekFrom::Start(0))?;
+    cache_file.set_len(0)?;
+
     cache_file.write_all(serde_json::to_string_pretty(&overwriteable)?.as_bytes())?;
     cache_file.unlock()?;
 
@@ -574,7 +585,7 @@ where
             .collect(),
     };
 
-    let submission = embedder.submit_batch(request.clone()).await?;
+    let submission = embedder.submit_batch(request).await?;
     let batch_id = submission.batch_id.clone();
     write_batch_metadata(
         cfg.provider_id(),

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -608,7 +608,8 @@ mod tests {
     use zqa_rag::{embedding::common::BatchSubmission, providers::ProviderId};
 
     use super::{
-        BatchEmbeddingMetadata, get_seq_id, handle_batch_check_status_cmd, write_batch_metadata,
+        BatchEmbeddingMetadata, BatchItem, get_seq_id, handle_batch_check_status_cmd,
+        write_batch_metadata,
     };
     use crate::cli::app::tests::create_test_context;
 
@@ -698,13 +699,28 @@ mod tests {
     #[test]
     fn write_batch_metadata_stores_correct_fields() {
         let tmp = tempdir().unwrap();
-        let hashes = vec!["hash-a".to_string(), "hash-b".to_string()];
+        let items = vec![
+            BatchItem {
+                file_path: std::path::PathBuf::from("/tmp/a.pdf"),
+                library_key: "KEY-A".into(),
+                title: "Title A".into(),
+                text: "text a".into(),
+                hash: 1,
+            },
+            BatchItem {
+                file_path: std::path::PathBuf::from("/tmp/b.pdf"),
+                library_key: "KEY-B".into(),
+                title: "Title B".into(),
+                text: "text b".into(),
+                hash: 2,
+            },
+        ];
 
         temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
             write_batch_metadata(
                 ProviderId::VoyageAI,
                 "voyage-3".into(),
-                hashes.clone(),
+                items,
                 make_submission("my-batch-id"),
             )
             .unwrap();
@@ -722,6 +738,11 @@ mod tests {
             assert_eq!(meta.batch_id, "my-batch-id");
             assert_eq!(meta.provider, ProviderId::VoyageAI);
             assert_eq!(meta.model, "voyage-3");
+            assert_eq!(meta.items.len(), 2);
+            assert_eq!(meta.items[0].library_key, "KEY-A");
+            assert_eq!(meta.items[0].hash, 1);
+            assert_eq!(meta.items[1].library_key, "KEY-B");
+            assert_eq!(meta.items[1].hash, 2);
             assert!(meta.succeeded.is_none());
             assert!(meta.failed.is_none());
         });

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -40,7 +40,10 @@
 //!   we scan a cache when inserting a batch into the backend to check conflicts (and the newest
 //!   one wins). Moreover, we maintain a cache of hashes (try saying that thrice quickly) with the
 //!   following semantics:
-//!   * This file is shared across batches.
+//!   * The file is named `.hash_cache`, and is placed in `~/.local/state/zqa/batches`.
+//!   * This file is shared across batches. Shared/exclusive locks to this file preclude other
+//!     file handles from accessing it (this is unlikely, but it is a stronger guarantee than doing
+//!     nothing).
 //!   * The file contains a map from text hashes to corresponding provider ID, provider model, and
 //!     the sequence number of the (newest) batch it belonged to.
 //!   * Before writing to the DB, we filter out items that match the hash, provider, and provider
@@ -51,32 +54,65 @@
 //! For the structure of this file, see [`BatchEmbeddingMetadata`].
 
 use std::{
+    collections::HashMap,
     fmt::Display,
-    fs,
-    hash::{DefaultHasher, Hash, Hasher},
-    io::{self, Write},
-    path::Path,
+    fs::{self, OpenOptions},
+    hash::{DefaultHasher, Hasher},
+    io::{self, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
 };
 
 use chrono::{DateTime, Utc};
 use humantime::format_duration;
 use serde::{Deserialize, Serialize};
 use zqa_rag::{
+    capabilities::BatchJobState,
     embedding::common::{BatchEmbeddingInput, BatchEmbeddingRequest, BatchSubmission},
+    llm::factory::BatchEmbeddingClient,
     providers::{ProviderId, registry::provider_registry},
 };
 
 use crate::{
     cli::{commands::BatchCommand, errors::CLIError},
     common::Context,
-    state::read_number,
+    utils::{
+        arrow::library_to_arrow_with_embeddings,
+        library::ZoteroItem,
+        terminal::{read_char, read_number},
+    },
 };
 use crate::{state::get_state_dir, utils::library::parse_library};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BatchItem {
+    file_path: PathBuf,
+    library_key: String,
+    title: String,
+    text: String,
+    hash: u64,
+}
+
+impl From<ZoteroItem> for BatchItem {
+    fn from(value: ZoteroItem) -> Self {
+        let mut hasher = DefaultHasher::new();
+        hasher.write(value.text.as_bytes());
+
+        Self {
+            file_path: value.metadata.file_path,
+            library_key: value.metadata.library_key,
+            title: value.metadata.title,
+            text: value.text,
+            hash: hasher.finish(),
+        }
+    }
+}
 
 /// Metadata about a batch embedding request. This is the file structure used to represent a batch
 /// in progress.
 #[derive(Debug, Serialize, Deserialize)]
 struct BatchEmbeddingMetadata {
+    /// The sequence number of this batch
+    seq_id: usize,
     /// The batch ID
     batch_id: String,
     /// The file ID from the provider's Files API
@@ -87,14 +123,26 @@ struct BatchEmbeddingMetadata {
     model: String,
     /// Date of creation (local time, in UTC). Used to give users context when referring to a batch.
     created_at: DateTime<Utc>,
-    /// Hashes of each text in this batch. Since our texts can be quite large, and we only need
-    /// equality tests, a hash is a simpler solution.
-    hashes: Vec<String>,
+    /// Items in this batch
+    items: Vec<BatchItem>,
     /// Optional indices to the hashes above if we know this information (by checking).
     succeeded: Option<Vec<usize>>,
     /// Optional indices to the hashes above if we know this information (by checking).
     failed: Option<Vec<usize>>,
 }
+
+#[derive(Serialize, Deserialize)]
+struct CacheEntry {
+    /// Embedding provider ID
+    provider_id: ProviderId,
+    /// Embedding model string
+    model: String,
+    /// Sequence number of the batch that added this hash.
+    seq_id: usize,
+}
+
+/// The structure stored in the hash cache.
+type HashCache = HashMap<u64, CacheEntry>;
 
 impl Display for BatchEmbeddingMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -109,7 +157,7 @@ impl Display for BatchEmbeddingMetadata {
             elapsed,
             self.provider.as_str(),
             self.model,
-            self.hashes.len()
+            self.items.len()
         ))
     }
 }
@@ -157,7 +205,7 @@ fn get_seq_id() -> Result<usize, CLIError> {
 ///
 /// * `provider` - The provider of the embedding model
 /// * `model` - The embedding model string
-/// * `hashes` - Hashes for the texts in this batch
+/// * `items` - The items in this batch
 /// * `submission` - The result of a `submit_batch` on a batch embedding provider
 ///
 /// # Errors
@@ -171,7 +219,7 @@ fn get_seq_id() -> Result<usize, CLIError> {
 fn write_batch_metadata(
     provider: ProviderId,
     model: String,
-    hashes: Vec<String>,
+    items: Vec<BatchItem>,
     submission: BatchSubmission,
 ) -> Result<(), CLIError> {
     let batch_dir = get_state_dir()?.join("batches");
@@ -179,21 +227,160 @@ fn write_batch_metadata(
         fs::create_dir_all(&batch_dir)?;
     }
 
+    let seq = get_seq_id()?;
     let metadata = BatchEmbeddingMetadata {
+        seq_id: seq,
         batch_id: submission.batch_id,
         file_id: submission.file_id,
         provider,
         model,
         created_at: Utc::now(),
-        hashes,
+        items,
         succeeded: None,
         failed: None,
     };
 
-    let seq = get_seq_id()?;
     let filename = format!("batch_{seq}.log");
     let contents = serde_json::to_string_pretty(&metadata)?;
     fs::write(batch_dir.join(filename), contents)?;
+
+    Ok(())
+}
+
+async fn prompt_and_fetch_batch_results<O, E>(
+    ctx: &mut Context<O, E>,
+    client: BatchEmbeddingClient,
+    batch: &BatchEmbeddingMetadata,
+) -> Result<(), CLIError>
+where
+    O: Write,
+    E: Write,
+{
+    writeln!(&mut ctx.out, "Fetch results now? ([y]/n)")?;
+    if read_char(&mut io::stdin().lock(), 'y', &['y', 'n']) != 'y' {
+        return Ok(());
+    }
+
+    let batch_id = batch.batch_id.as_str();
+    let results = client.fetch_results(batch_id).await?;
+
+    // TODO: attempt a best-effort match anyway; maybe use a boolean flag or something and handle it
+    // specially later.
+    if results.succeeded.len() + results.failed.len() != batch.items.len() {
+        writeln!(
+            &mut ctx.err,
+            "Length mismatch between batch results and saved batch. The file may have been corrupted."
+        )?;
+    }
+
+    let ids_to_items = batch
+        .items
+        .iter()
+        .map(|i| (i.library_key.as_str(), i)) // we use `library_key` as the id in the batch
+        .collect::<HashMap<&str, &BatchItem>>();
+
+    let items_to_embeddings: Vec<(&BatchItem, Vec<f32>)> = results.succeeded.iter().filter_map(|res| {
+        if let Some(item) = ids_to_items.get(res.id.as_str()) {
+            Some((*item, res.embedding.clone()))
+        } else {
+            writeln!(&mut ctx.err,
+                "Item {} from batch response not in library. If you removed items from your library, this is fine.",
+                res.id
+            ).ok()?;
+
+            None
+        }
+    })
+    .collect();
+
+    let batch_dir = get_state_dir()?.join("batches");
+
+    let mut buf = Vec::<u8>::new(); // allocate before obtaining lock
+    let mut cache_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(batch_dir.join(".hash_cache"))?;
+
+    cache_file.lock()?;
+    cache_file.read_to_end(&mut buf)?;
+
+    // First batch ever: the cache will be empty but the file exists
+    let cache = if buf.is_empty() {
+        HashCache::new()
+    } else {
+        serde_json::from_slice::<HashCache>(buf.as_ref())?
+    };
+
+    // Filter the items in `batch` using `items_to_embeddings`: if the cache doesn't contain it,
+    // it's new so we keep it; otherwise, look for a mismatch
+    let to_insert = items_to_embeddings
+        .into_iter()
+        .filter(|(item, _)| {
+            cache.get(&item.hash).is_none_or(|entry| {
+                entry.provider_id != batch.provider || entry.model != batch.model
+            })
+        })
+        .collect::<Vec<_>>();
+
+    writeln!(
+        &mut ctx.out,
+        "{} items to insert, {} items dropped as duplicates.",
+        to_insert.len(),
+        batch.items.len() - to_insert.len()
+    )?;
+
+    let library_keys: Vec<&str> = to_insert
+        .iter()
+        .map(|(i, _)| i.library_key.as_str())
+        .collect();
+    let titles: Vec<&str> = to_insert.iter().map(|(i, _)| i.title.as_str()).collect();
+    let file_paths: Vec<&str> = to_insert
+        .iter()
+        .map(|(i, _)| {
+            i.file_path.to_str().ok_or(CLIError::CommandError(format!(
+                "Invalid file path for item: {}",
+                i.title.clone()
+            )))
+        })
+        .collect::<Result<_, _>>()?;
+    let pdf_texts: Vec<&str> = to_insert.iter().map(|(i, _)| i.text.as_str()).collect();
+    let embeddings: Vec<Vec<f32>> = to_insert.into_iter().map(|(_, e)| e).collect();
+
+    let embedding_config = ctx
+        .config
+        .get_embedding_config()
+        .ok_or(CLIError::ConfigError("Embedding config not set up.".into()))?;
+
+    ctx.store
+        .upsert_batches(vec![library_to_arrow_with_embeddings(
+            &library_keys,
+            &titles,
+            &file_paths,
+            &pdf_texts,
+            embeddings,
+            &embedding_config,
+        )?])
+        .await?;
+
+    let (mut overwriteable, rest): (HashMap<_, _>, HashMap<_, _>) =
+        cache.into_iter().partition(|(k, v)| {
+            batch.items.iter().any(|i| i.hash == *k)
+                && v.provider_id == batch.provider
+                && v.model == batch.model
+                && v.seq_id < batch.seq_id
+        });
+
+    // For the matches, update the batch seq number
+    overwriteable.iter_mut().for_each(|(_, v)| {
+        v.seq_id = batch.seq_id;
+    });
+
+    overwriteable.extend(rest);
+    cache_file.seek(SeekFrom::Start(0))?;
+    cache_file.set_len(0)?;
+    cache_file.write_all(serde_json::to_string_pretty(&overwriteable)?.as_bytes())?;
+    cache_file.unlock()?;
 
     Ok(())
 }
@@ -301,6 +488,9 @@ where
     writeln!(&mut ctx.out, "Current status: {}", status.as_str())?;
 
     // TODO: For better UX, if this is completed, prompt to fetch, when that subcmd is implemented
+    if status == BatchJobState::Completed {
+        prompt_and_fetch_batch_results(ctx, embedder, &selected_batch).await?;
+    }
 
     Ok(())
 }
@@ -320,6 +510,7 @@ where
             return Ok(());
         }
     };
+    let new_items: Vec<BatchItem> = new_items.into_iter().map(Into::into).collect();
 
     let cfg = ctx.config.get_embedding_config();
     let Some(cfg) = cfg else {
@@ -342,35 +533,24 @@ where
         Ok(embedder) => embedder,
     };
 
-    let hashes = new_items
-        .iter()
-        .map(|item| {
-            // TODO: Consider using `sha2`, `fxhash`, or similar
-            let mut hasher = DefaultHasher::new();
-            item.text.hash(&mut hasher);
-
-            hasher.finish().to_string()
-        })
-        .collect::<Vec<_>>();
-
     let request = BatchEmbeddingRequest {
         model: cfg.model_name().into(),
         dims: cfg.dims(),
         inputs: new_items
-            .into_iter()
+            .iter()
             .map(|item| BatchEmbeddingInput {
-                id: item.metadata.library_key,
-                text: item.text,
+                id: item.library_key.clone(),
+                text: item.text.clone(),
             })
             .collect(),
     };
 
-    let submission = embedder.submit_batch(request).await?;
+    let submission = embedder.submit_batch(request.clone()).await?;
     let batch_id = submission.batch_id.clone();
     write_batch_metadata(
         cfg.provider_id(),
         cfg.model_name().into(),
-        hashes,
+        new_items,
         submission,
     )?;
 
@@ -390,7 +570,6 @@ where
     match subcmd {
         BatchCommand::Create => handle_batch_create_cmd(ctx).await,
         BatchCommand::CheckStatus => handle_batch_check_status_cmd(ctx).await,
-        BatchCommand::FetchResults => todo!(),
     }
 }
 
@@ -517,7 +696,6 @@ mod tests {
             assert_eq!(meta.batch_id, "my-batch-id");
             assert_eq!(meta.provider, ProviderId::VoyageAI);
             assert_eq!(meta.model, "voyage-3");
-            assert_eq!(meta.hashes, hashes);
             assert!(meta.succeeded.is_none());
             assert!(meta.failed.is_none());
         });

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -58,7 +58,7 @@ use std::{
     fmt::Display,
     fs::{self, OpenOptions},
     hash::{DefaultHasher, Hasher},
-    io::{self, Read, Seek, SeekFrom, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
 };
 
@@ -247,6 +247,9 @@ fn write_batch_metadata(
     Ok(())
 }
 
+/// Interactively fetch batch results, and update the LanceDB store and the hash cache following the
+/// protocol above.
+#[allow(clippy::too_many_lines)]
 async fn prompt_and_fetch_batch_results<O, E>(
     ctx: &mut Context<O, E>,
     client: BatchEmbeddingClient,
@@ -300,6 +303,7 @@ where
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(batch_dir.join(".hash_cache"))?;
 
     cache_file.lock()?;
@@ -349,9 +353,9 @@ where
         });
 
     // For the matches, update the batch seq number
-    overwriteable.iter_mut().for_each(|(_, v)| {
+    for v in overwriteable.values_mut() {
         v.seq_id = batch.seq_id;
-    });
+    }
 
     overwriteable.extend(rest);
 
@@ -399,8 +403,7 @@ where
         .await?;
     ctx.store.create_or_update_indices().await?;
 
-    cache_file.seek(SeekFrom::Start(0))?;
-    cache_file.set_len(0)?;
+    // We already set `.truncate(true)`
     cache_file.write_all(serde_json::to_string_pretty(&overwriteable)?.as_bytes())?;
     cache_file.unlock()?;
 
@@ -515,7 +518,7 @@ where
 
     // TODO: For better UX, if this is completed, prompt to fetch, when that subcmd is implemented
     if status == BatchJobState::Completed {
-        prompt_and_fetch_batch_results(ctx, embedder, &selected_batch).await?;
+        prompt_and_fetch_batch_results(ctx, embedder, selected_batch).await?;
     }
 
     Ok(())

--- a/zqa/src/cli/handlers/library.rs
+++ b/zqa/src/cli/handlers/library.rs
@@ -417,8 +417,7 @@ async fn fix_zero_embeddings<O: Write, E: Write>(ctx: &mut Context<O, E>) -> Res
         nonempty_zero_subset,
         embedding_config.clone(),
         include_embeddings,
-    )
-    .await?;
+    )?;
 
     let batches = vec![nonempty_zero_subset_batch.clone()];
 

--- a/zqa/src/cli/handlers/library.rs
+++ b/zqa/src/cli/handlers/library.rs
@@ -413,11 +413,8 @@ async fn fix_zero_embeddings<O: Write, E: Write>(ctx: &mut Context<O, E>) -> Res
     }
 
     let include_embeddings = ctx.store.exists().await;
-    let nonempty_zero_subset_batch = library_to_arrow(
-        nonempty_zero_subset,
-        embedding_config.clone(),
-        include_embeddings,
-    )?;
+    let nonempty_zero_subset_batch =
+        library_to_arrow(&nonempty_zero_subset, &embedding_config, include_embeddings)?;
 
     let batches = vec![nonempty_zero_subset_batch.clone()];
 

--- a/zqa/src/lib.rs
+++ b/zqa/src/lib.rs
@@ -211,7 +211,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let store = LanceZoteroStore::from_config(&config).await?;
+    let store = LanceZoteroStore::from_config(&config)?;
     let context = Context {
         state: State::default(),
         config,

--- a/zqa/src/state.rs
+++ b/zqa/src/state.rs
@@ -15,6 +15,7 @@ use zqa_rag::{
 };
 
 use crate::config::{BaseDirError, Config, get_config_dir};
+use crate::utils::terminal::{read_char, read_number, read_password};
 
 /// ANSI escape code for dimming text
 const DIM_TEXT: &str = "\x1b[2m";
@@ -179,78 +180,6 @@ pub(crate) fn check_or_create_first_run_file() -> Result<bool, StateError> {
         fs::create_dir_all(&state_dir)?;
         fs::File::create(&first_run_file)?;
         Ok(true)
-    }
-}
-
-/// Read a line of input.
-fn read_line<R: BufRead>(reader: &mut R) -> String {
-    let mut input = String::new();
-    reader.read_line(&mut input).expect("Failed to read input");
-
-    input
-}
-
-/// Read a password from standard input.
-fn read_password<R: BufRead>(reader: &mut R, is_terminal: bool) -> Result<String, StateError> {
-    if is_terminal {
-        rpassword::read_password().map_err(|e| StateError::PasswordReadError(e.to_string()))
-    } else {
-        Ok(read_line(reader))
-    }
-}
-
-/// Read a character from standard input and return it, handling Enter as a default.
-///
-/// # Arguments:
-///
-/// * `reader` - The input reader.
-/// * `default` - The default if Enter is pressed.
-/// * `valid_set` - The valid set of characters.
-fn read_char<R: BufRead>(reader: &mut R, default: char, valid_set: &[char]) -> char {
-    loop {
-        print!("> ");
-        let input = read_line(reader);
-        let choice = input.chars().next().unwrap_or(default).to_ascii_lowercase();
-
-        if valid_set.contains(&choice) {
-            return choice;
-        }
-
-        if choice == '\n' {
-            return default;
-        }
-    }
-}
-
-/// Read an integer from standard input, and validate that it is within bounds.
-///
-/// # Arguments:
-///
-/// * `reader` - The input reader.
-/// * `default` - The default value if Enter is pressed.
-/// * `bounds` - Lower and upper bounds to accept. Lower bound is inclusive, upper is exclusive.
-pub(crate) fn read_number<R: BufRead>(reader: &mut R, default: u8, bounds: (u8, u8)) -> u8 {
-    loop {
-        print!("> ");
-        let input = read_line(reader);
-        let input = input.trim();
-        if input.is_empty() {
-            return default;
-        }
-
-        let choice = input.parse::<u8>();
-
-        match choice {
-            Ok(num) => {
-                if bounds.0 <= num && num < bounds.1 {
-                    return num;
-                }
-                println!("Choice must be in [{}, {}).", bounds.0, bounds.1);
-            }
-            Err(_) => {
-                println!("Choice must be in [{}, {}).", bounds.0, bounds.1);
-            }
-        }
     }
 }
 

--- a/zqa/src/store/lance.rs
+++ b/zqa/src/store/lance.rs
@@ -59,7 +59,8 @@ impl LanceZoteroStore {
     }
 
     /// Create a Lance-backed Zotero store from an embedding configuration.
-    pub async fn from_embedding_config(embedding_config: EmbeddingProviderConfig) -> Self {
+    #[must_use]
+    pub fn from_embedding_config(embedding_config: EmbeddingProviderConfig) -> Self {
         let schema = Arc::new(get_schema(embedding_config.provider(), true));
         Self::from_schema(embedding_config, schema)
     }
@@ -69,12 +70,12 @@ impl LanceZoteroStore {
     /// # Errors
     ///
     /// Returns a [`CLIError`] if no embedding configuration is available.
-    pub(crate) async fn from_config(config: &Config) -> Result<Self, CLIError> {
+    pub(crate) fn from_config(config: &Config) -> Result<Self, CLIError> {
         let embedding_config = config.get_embedding_config().ok_or(CLIError::ConfigError(
             "Could not get embedding config".into(),
         ))?;
 
-        Ok(Self::from_embedding_config(embedding_config).await)
+        Ok(Self::from_embedding_config(embedding_config))
     }
 
     /// Upsert Arrow record batches into the LanceDB table by Zotero library key.
@@ -236,7 +237,7 @@ impl ZoteroStore for LanceZoteroStore {
     /// Returns a [`CLIError`] if the upsert fails.
     async fn upsert_items(&self, items: Vec<ZoteroItem>) -> Result<(), Self::StoreError> {
         let include_embeddings = self.exists().await;
-        let batch = library_to_arrow(items, self.embedding_config.clone(), include_embeddings)?;
+        let batch = library_to_arrow(&items, &self.embedding_config, include_embeddings)?;
         self.upsert_batches(vec![batch]).await
     }
 

--- a/zqa/src/store/lance.rs
+++ b/zqa/src/store/lance.rs
@@ -60,7 +60,7 @@ impl LanceZoteroStore {
 
     /// Create a Lance-backed Zotero store from an embedding configuration.
     pub async fn from_embedding_config(embedding_config: EmbeddingProviderConfig) -> Self {
-        let schema = Arc::new(get_schema(embedding_config.provider(), true).await);
+        let schema = Arc::new(get_schema(embedding_config.provider(), true));
         Self::from_schema(embedding_config, schema)
     }
 
@@ -236,8 +236,7 @@ impl ZoteroStore for LanceZoteroStore {
     /// Returns a [`CLIError`] if the upsert fails.
     async fn upsert_items(&self, items: Vec<ZoteroItem>) -> Result<(), Self::StoreError> {
         let include_embeddings = self.exists().await;
-        let batch =
-            library_to_arrow(items, self.embedding_config.clone(), include_embeddings).await?;
+        let batch = library_to_arrow(items, self.embedding_config.clone(), include_embeddings)?;
         self.upsert_batches(vec![batch]).await
     }
 

--- a/zqa/src/utils/arrow.rs
+++ b/zqa/src/utils/arrow.rs
@@ -1,6 +1,8 @@
 use std::{path::PathBuf, sync::Arc};
 
-use arrow_array::{ArrayRef, RecordBatch, StringArray, cast::AsArray};
+use arrow_array::{
+    ArrayRef, FixedSizeListArray, Float32Array, RecordBatch, StringArray, cast::AsArray,
+};
 use arrow_schema;
 use thiserror::Error;
 use zqa_rag::{
@@ -113,7 +115,7 @@ pub(crate) async fn lancedb_exists() -> bool {
 /// # Returns
 ///
 /// The schema in Arrow format.
-pub async fn get_schema(
+pub fn get_schema(
     embedding_provider: EmbeddingProvider,
     include_embeddings: bool,
 ) -> arrow_schema::Schema {
@@ -162,12 +164,12 @@ pub async fn get_schema(
 /// # Returns
 ///
 /// A `RecordBatch` that can be used to interact with `LanceDB`.
-pub async fn library_to_arrow(
+pub fn library_to_arrow(
     items: Vec<ZoteroItem>,
     embedding_config: EmbeddingProviderConfig,
     include_embeddings: bool,
 ) -> Result<RecordBatch, ArrowError> {
-    let schema = Arc::new(get_schema(embedding_config.provider(), include_embeddings).await);
+    let schema = Arc::new(get_schema(embedding_config.provider(), include_embeddings));
 
     // Convert ZoteroItemMetadata to Arrow arrays
     let library_keys = StringArray::from(
@@ -261,7 +263,86 @@ pub async fn full_library_to_arrow(
     log::info!("Finished parsing library items.");
 
     let include_embeddings = lancedb_exists().await;
-    library_to_arrow(lib_items, store.get_embedding_config(), include_embeddings).await
+    library_to_arrow(lib_items, store.get_embedding_config(), include_embeddings)
+}
+
+/// Given metadata about Zotero items, *including embeddings*, inserts them into the LanceDB store.
+///
+/// This function does not check that the metadata provided correspond to items in Zotero; nor does
+/// it query Zotero at all. This function is a "manual" alternative to [`library_to_arrow`] when you
+/// already have embeddings. This function also assumes that the array slices passed all have the
+/// same length, and that for any $i$, the $i$th element of each array corresponds to the same item.
+///
+/// # Arguments
+///
+/// * `library_keys` - The library keys of the items
+//  * `titles` - The titles of the items
+//  * `file_paths` - The UTF-8 file paths to the items
+//  * `pdf_texts` - The full texts for each item
+//  * `embeddings` - The embeddings for each element
+//  * `embedding_config` - The embedding config
+///
+/// # Returns
+///
+/// An Arrow [`RecordBatch`] with the Zotero schema and passed items.
+///
+/// # Errors
+///
+/// * `ArrowError::Other` - if the lengths of the arrays do not match, or any of the embedding
+///   vectors do not have the dimensions configured in `embedding_config`.
+/// * `ArrowError::ArrowSchemaError` - if the schema does not match the items.
+pub fn library_to_arrow_with_embeddings(
+    library_keys: &[&str],
+    titles: &[&str],
+    file_paths: &[&str],
+    pdf_texts: &[&str],
+    embeddings: Vec<Vec<f32>>,
+    embedding_config: &EmbeddingProviderConfig,
+) -> Result<RecordBatch, ArrowError> {
+    if library_keys.len() != titles.len()
+        || library_keys.len() != file_paths.len()
+        || library_keys.len() != pdf_texts.len()
+        || library_keys.len() != embeddings.len()
+    {
+        return Err(ArrowError::Other(
+            "Passed slices do not have equal lengths.".into(),
+        ));
+    }
+
+    let expected_dim = embedding_config.dims();
+    if embeddings.iter().any(|e| e.len() != expected_dim) {
+        return Err(ArrowError::Other(format!(
+            "All embeddings must have dimension {expected_dim}."
+        )));
+    }
+
+    let schema = Arc::new(get_schema(embedding_config.provider(), true));
+    let library_keys = StringArray::from(Vec::from(library_keys));
+    let titles = StringArray::from(Vec::from(titles));
+    let pdf_texts = StringArray::from(Vec::from(pdf_texts));
+    let file_paths = StringArray::from(Vec::from(file_paths));
+
+    let flattened_embeddings = embeddings.into_iter().flatten().collect::<Vec<_>>();
+    let embeddings_array = Float32Array::from(flattened_embeddings);
+    let field = Arc::new(arrow_schema::Field::new(
+        "item",
+        arrow_schema::DataType::Float32,
+        true,
+    ));
+
+    let embeddings_array =
+        FixedSizeListArray::new(field, expected_dim as i32, Arc::new(embeddings_array), None);
+
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(library_keys),
+            Arc::new(titles),
+            Arc::new(file_paths),
+            Arc::new(pdf_texts),
+            Arc::new(embeddings_array),
+        ],
+    )?)
 }
 
 #[cfg(test)]
@@ -310,7 +391,7 @@ mod tests {
 
         let record_batch = temp_env::async_with_vars([("LANCEDB_URI", Some(&db_uri))], async {
             let embedding_config = config.get_embedding_config().unwrap();
-            let schema = Arc::new(get_schema(embedding_config.provider(), true).await);
+            let schema = Arc::new(get_schema(embedding_config.provider(), true));
             let store = LanceZoteroStore::from_schema(embedding_config, schema);
             full_library_to_arrow(&store, Some(0), Some(5)).await
         })

--- a/zqa/src/utils/arrow.rs
+++ b/zqa/src/utils/arrow.rs
@@ -276,11 +276,11 @@ pub async fn full_library_to_arrow(
 /// # Arguments
 ///
 /// * `library_keys` - The library keys of the items
-//  * `titles` - The titles of the items
-//  * `file_paths` - The UTF-8 file paths to the items
-//  * `pdf_texts` - The full texts for each item
-//  * `embeddings` - The embeddings for each element
-//  * `embedding_config` - The embedding config
+/// * `titles` - The titles of the items
+/// * `file_paths` - The UTF-8 file paths to the items
+/// * `pdf_texts` - The full texts for each item
+/// * `embeddings` - The embeddings for each element
+/// * `embedding_config` - The embedding config
 ///
 /// # Returns
 ///

--- a/zqa/src/utils/arrow.rs
+++ b/zqa/src/utils/arrow.rs
@@ -115,6 +115,7 @@ pub(crate) async fn lancedb_exists() -> bool {
 /// # Returns
 ///
 /// The schema in Arrow format.
+#[must_use]
 pub fn get_schema(
     embedding_provider: EmbeddingProvider,
     include_embeddings: bool,
@@ -165,8 +166,8 @@ pub fn get_schema(
 ///
 /// A `RecordBatch` that can be used to interact with `LanceDB`.
 pub fn library_to_arrow(
-    items: Vec<ZoteroItem>,
-    embedding_config: EmbeddingProviderConfig,
+    items: &[ZoteroItem],
+    embedding_config: &EmbeddingProviderConfig,
     include_embeddings: bool,
 ) -> Result<RecordBatch, ArrowError> {
     let schema = Arc::new(get_schema(embedding_config.provider(), include_embeddings));
@@ -213,7 +214,7 @@ pub fn library_to_arrow(
     ];
 
     if include_embeddings {
-        let embedding_provider = get_embedding_provider_with_config(&embedding_config)?;
+        let embedding_provider = get_embedding_provider_with_config(embedding_config)?;
         let query_vec = embedding_provider.compute_source_embeddings(Arc::new(pdf_texts))?;
         let query_vec = query_vec.as_fixed_size_list();
 
@@ -263,7 +264,11 @@ pub async fn full_library_to_arrow(
     log::info!("Finished parsing library items.");
 
     let include_embeddings = lancedb_exists().await;
-    library_to_arrow(lib_items, store.get_embedding_config(), include_embeddings)
+    library_to_arrow(
+        &lib_items,
+        &store.get_embedding_config(),
+        include_embeddings,
+    )
 }
 
 /// Given metadata about Zotero items, *including embeddings*, inserts them into the LanceDB store.
@@ -330,6 +335,7 @@ pub fn library_to_arrow_with_embeddings(
         true,
     ));
 
+    #[allow(clippy::cast_possible_truncation)]
     let embeddings_array =
         FixedSizeListArray::new(field, expected_dim as i32, Arc::new(embeddings_array), None);
 

--- a/zqa/src/utils/terminal.rs
+++ b/zqa/src/utils/terminal.rs
@@ -1,3 +1,7 @@
+use std::io::BufRead;
+
+use crate::state::StateError;
+
 /// ANSI escape code for dimming text
 pub const DIM_TEXT: &str = "\x1b[2m";
 
@@ -15,3 +19,81 @@ pub const RED: &str = "\x1b[31m";
 
 /// ANSI escape code for red, bold text
 pub const RED_BOLD: &str = "\x1b[31;1m";
+
+/// Read a line of input.
+pub(crate) fn read_line<R: BufRead>(reader: &mut R) -> String {
+    let mut input = String::new();
+    reader.read_line(&mut input).expect("Failed to read input");
+
+    input
+}
+
+/// Read a password from standard input.
+pub(crate) fn read_password<R: BufRead>(
+    reader: &mut R,
+    is_terminal: bool,
+) -> Result<String, StateError> {
+    if is_terminal {
+        rpassword::read_password().map_err(|e| StateError::PasswordReadError(e.to_string()))
+    } else {
+        Ok(read_line(reader))
+    }
+}
+
+/// Read a character from standard input and return it, handling Enter as a default.
+///
+/// This function does not distinguish between lower- and uppercase options, and returns the
+/// lowercase version of the character.
+///
+/// # Arguments:
+///
+/// * `reader` - The input reader.
+/// * `default` - The default if Enter is pressed.
+/// * `valid_set` - The valid set of characters, in lowercase.
+pub(crate) fn read_char<R: BufRead>(reader: &mut R, default: char, valid_set: &[char]) -> char {
+    loop {
+        print!("> ");
+        let input = read_line(reader);
+        let choice = input.chars().next().unwrap_or(default).to_ascii_lowercase();
+
+        if valid_set.contains(&choice) {
+            return choice;
+        }
+
+        if choice == '\n' {
+            return default;
+        }
+    }
+}
+
+/// Read an integer from standard input, and validate that it is within bounds.
+///
+/// # Arguments:
+///
+/// * `reader` - The input reader.
+/// * `default` - The default value if Enter is pressed.
+/// * `bounds` - Lower and upper bounds to accept. Lower bound is inclusive, upper is exclusive.
+pub(crate) fn read_number<R: BufRead>(reader: &mut R, default: u8, bounds: (u8, u8)) -> u8 {
+    loop {
+        print!("> ");
+        let input = read_line(reader);
+        let input = input.trim();
+        if input.is_empty() {
+            return default;
+        }
+
+        let choice = input.parse::<u8>();
+
+        match choice {
+            Ok(num) => {
+                if bounds.0 <= num && num < bounds.1 {
+                    return num;
+                }
+                println!("Choice must be in [{}, {}).", bounds.0, bounds.1);
+            }
+            Err(_) => {
+                println!("Choice must be in [{}, {}).", bounds.0, bounds.1);
+            }
+        }
+    }
+}

--- a/zqa/tests/new_library.rs
+++ b/zqa/tests/new_library.rs
@@ -49,7 +49,7 @@ async fn test_integration_works() {
     };
 
     let embedding_config = config.get_embedding_config().unwrap();
-    let store = LanceZoteroStore::from_embedding_config(embedding_config).await;
+    let store = LanceZoteroStore::from_embedding_config(embedding_config);
 
     let record_batch = full_library_to_arrow(&store, None, None).await;
     test_ok!(record_batch);


### PR DESCRIPTION
This is the first of two PRs implementing batch API command handlers. The overall goal is to have user-facing commands to interact with batch APIs and allow for retrying failed items. This PR implements a basic version of the `/batch fetch` command, which retrieves results from the server. Error handling is added in the second PR.

Contributes to: ZOT-127