### PR TITLE
feat: stub success/failure paths

### DIFF
--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -87,7 +87,7 @@ use crate::{
 };
 use crate::{state::get_state_dir, utils::library::parse_library};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct BatchItem {
     file_path: PathBuf,
     library_key: String,
@@ -114,7 +114,7 @@ impl From<ZoteroItem> for BatchItem {
 
 /// Metadata about a batch embedding request. This is the file structure used to represent a batch
 /// in progress.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct BatchEmbeddingMetadata {
     /// The sequence number of this batch
     seq_id: usize,
@@ -420,20 +420,20 @@ where
         return Ok(());
     }
 
+    let batch_dir = get_state_dir()?.join("batches");
+
     let batch_id = batch.batch_id.as_str();
     let results = client.fetch_results(batch_id).await?;
 
     // TODO: attempt a best-effort match anyway; maybe use a boolean flag or something and handle it
     // specially later.
     if results.succeeded.len() + results.failed.len() != batch.items.len() {
-        writeln!(
-            &mut ctx.err,
-            "Length mismatch between batch results and saved batch. The file may have been corrupted."
-        )?;
+        return Err(CLIError::CommandError("Length mismatch between batch results and saved batch. The file may have been corrupted.".into()));
     }
 
     match (results.succeeded.is_empty(), results.failed.is_empty()) {
         (true, true) => {
+            // no results
             writeln!(
                 &mut ctx.out,
                 "The batch API did not send any results despite the batch being completed."
@@ -459,21 +459,46 @@ where
             // complete success
             handle_successful_batch_results(ctx, batch, &results.succeeded).await?;
 
-            let batch_dir = get_state_dir()?.join("batches");
-            if results.failed.is_empty() {
-                fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
-            }
+            fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
         }
         (false, false) => {
             // partial success
             writeln!(
                 &mut ctx.out,
-                "{} of {} items succeeded.",
+                "{} of {} items succeeded, and will be imported.",
                 results.succeeded.len(),
                 results.succeeded.len() + results.failed.len()
             )?;
 
             // TODO: prompt for retry
+
+            handle_successful_batch_results(ctx, batch, &results.succeeded).await?;
+
+            let ids_to_idx: HashMap<&str, usize> = batch
+                .items
+                .iter()
+                .enumerate()
+                .map(|(i, item)| (item.library_key.as_str(), i))
+                .collect();
+
+            let succ_idx: Vec<usize> = results
+                .succeeded
+                .iter()
+                .filter_map(|r| ids_to_idx.get(r.id.as_str()).copied())
+                .collect();
+            let failed_idx: Vec<usize> = results
+                .failed
+                .iter()
+                .filter_map(|r| ids_to_idx.get(r.id.as_str()).copied())
+                .collect();
+
+            let mut batch_metadata = batch.clone();
+            batch_metadata.succeeded = Some(succ_idx);
+            batch_metadata.failed = Some(failed_idx);
+            fs::write(
+                batch_dir.join(format!("batch_{}.log", batch.seq_id)),
+                serde_json::to_string_pretty(&batch_metadata)?,
+            )?;
         }
     }
 

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -738,8 +738,10 @@ where
 mod tests {
     use std::fs;
 
+    use chrono::{Duration, Utc};
     use serial_test::serial;
     use tempfile::tempdir;
+    use zqa_macros::{test_contains, test_eq};
     use zqa_rag::{embedding::common::BatchSubmission, providers::ProviderId};
 
     use super::{
@@ -747,6 +749,7 @@ mod tests {
         write_batch_metadata,
     };
     use crate::cli::app::tests::create_test_context;
+    use crate::utils::library::{ZoteroItem, ZoteroItemMetadata};
 
     fn make_submission(batch_id: &str) -> BatchSubmission {
         BatchSubmission {
@@ -759,7 +762,7 @@ mod tests {
     fn get_seq_id_returns_one_when_batch_dir_absent() {
         let tmp = tempdir().unwrap();
         temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
-            assert_eq!(get_seq_id().unwrap(), 1);
+            test_eq!(get_seq_id().unwrap(), 1);
         });
     }
 
@@ -770,7 +773,7 @@ mod tests {
         fs::create_dir_all(&batch_dir).unwrap();
 
         temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
-            assert_eq!(get_seq_id().unwrap(), 1);
+            test_eq!(get_seq_id().unwrap(), 1);
         });
     }
 
@@ -784,7 +787,7 @@ mod tests {
         fs::write(batch_dir.join("batch_3.log"), "").unwrap();
 
         temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
-            assert_eq!(get_seq_id().unwrap(), 4);
+            test_eq!(get_seq_id().unwrap(), 4);
         });
     }
 
@@ -797,7 +800,7 @@ mod tests {
         fs::write(batch_dir.join("cache.bin"), "").unwrap();
 
         temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
-            assert_eq!(get_seq_id().unwrap(), 1);
+            test_eq!(get_seq_id().unwrap(), 1);
         });
     }
 
@@ -811,7 +814,7 @@ mod tests {
         fs::write(batch_dir.join("batch_abc.log"), "").unwrap();
 
         temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
-            assert_eq!(get_seq_id().unwrap(), 2);
+            test_eq!(get_seq_id().unwrap(), 2);
         });
     }
 
@@ -865,19 +868,19 @@ mod tests {
                 .unwrap()
                 .filter_map(std::result::Result::ok)
                 .collect();
-            assert_eq!(files.len(), 1);
+            test_eq!(files.len(), 1);
 
             let content = fs::read_to_string(files[0].path()).unwrap();
             let meta: BatchEmbeddingMetadata = serde_json::from_str(&content).unwrap();
 
-            assert_eq!(meta.batch_id, "my-batch-id");
-            assert_eq!(meta.provider, ProviderId::VoyageAI);
-            assert_eq!(meta.model, "voyage-3");
-            assert_eq!(meta.items.len(), 2);
-            assert_eq!(meta.items[0].library_key, "KEY-A");
-            assert_eq!(meta.items[0].hash, 1);
-            assert_eq!(meta.items[1].library_key, "KEY-B");
-            assert_eq!(meta.items[1].hash, 2);
+            test_eq!(meta.batch_id, "my-batch-id");
+            test_eq!(meta.provider, ProviderId::VoyageAI);
+            test_eq!(meta.model, "voyage-3");
+            test_eq!(meta.items.len(), 2);
+            test_eq!(meta.items[0].library_key, "KEY-A");
+            test_eq!(meta.items[0].hash, 1);
+            test_eq!(meta.items[1].library_key, "KEY-B");
+            test_eq!(meta.items[1].hash, 2);
             assert!(meta.succeeded.is_none());
             assert!(meta.failed.is_none());
         });
@@ -944,10 +947,128 @@ mod tests {
                 assert!(result.is_ok());
 
                 let err = String::from_utf8(ctx.err.into_inner()).unwrap();
-                assert!(err.contains("No batches have been submitted"));
+                test_contains!(err, "No batches have been submitted");
             },
         )
         .await;
+    }
+
+    #[test]
+    fn from_zotero_item_maps_all_fields() {
+        let zi = ZoteroItem {
+            metadata: ZoteroItemMetadata {
+                library_key: "KEY-1".into(),
+                title: "Some Title".into(),
+                file_path: std::path::PathBuf::from("/tmp/x.pdf"),
+                authors: Some(vec!["Author A".into()]),
+            },
+            text: "body text".into(),
+        };
+
+        let bi: BatchItem = zi.into();
+        test_eq!(bi.library_key, "KEY-1");
+        test_eq!(bi.title, "Some Title");
+        test_eq!(bi.file_path, std::path::PathBuf::from("/tmp/x.pdf"));
+        test_eq!(bi.text, "body text");
+    }
+
+    fn make_zotero_item(text: &str) -> ZoteroItem {
+        ZoteroItem {
+            metadata: ZoteroItemMetadata {
+                library_key: "K".into(),
+                title: "T".into(),
+                file_path: std::path::PathBuf::from("/tmp/p.pdf"),
+                authors: None,
+            },
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn from_zotero_item_hash_is_deterministic() {
+        let a: BatchItem = make_zotero_item("identical text").into();
+        let b: BatchItem = make_zotero_item("identical text").into();
+        test_eq!(a.hash, b.hash);
+    }
+
+    #[test]
+    fn from_zotero_item_hash_distinguishes_text() {
+        let a: BatchItem = make_zotero_item("one").into();
+        let b: BatchItem = make_zotero_item("two").into();
+        assert_ne!(a.hash, b.hash);
+    }
+
+    fn make_metadata_at(when: chrono::DateTime<Utc>, items_count: usize) -> BatchEmbeddingMetadata {
+        let items = (0..items_count)
+            .map(|i| BatchItem {
+                file_path: std::path::PathBuf::from(format!("/tmp/{i}.pdf")),
+                library_key: format!("K{i}"),
+                title: format!("T{i}"),
+                text: format!("text {i}"),
+                hash: i as u64,
+            })
+            .collect();
+        BatchEmbeddingMetadata {
+            seq_id: 1,
+            batch_id: "bid".into(),
+            file_id: "fid".into(),
+            provider: ProviderId::VoyageAI,
+            model: "voyage-3".into(),
+            created_at: when,
+            items,
+            succeeded: None,
+            failed: None,
+        }
+    }
+
+    #[test]
+    fn display_includes_provider_model_and_count() {
+        let meta = make_metadata_at(Utc::now() - Duration::seconds(30), 3);
+        let s = format!("{meta}");
+
+        test_contains!(s, "voyageai");
+        test_contains!(s, "voyage-3");
+        test_contains!(s, "3 items");
+    }
+
+    #[test]
+    fn display_handles_future_created_at() {
+        // A negative duration can't be converted to `std::time::Duration`, so the formatter
+        // falls back to the "Unknown" branch.
+        let meta = make_metadata_at(Utc::now() + Duration::days(365), 0);
+        let s = format!("{meta}");
+        assert!(s.contains("Unknown"), "expected unknown-time fallback: {s}");
+    }
+
+    #[test]
+    fn get_seq_id_handles_gaps_in_sequence() {
+        let tmp = tempdir().unwrap();
+        let batch_dir = tmp.path().join("batches");
+        fs::create_dir_all(&batch_dir).unwrap();
+        // Gaps from deleted batches: next seq should be (max + 1), not (count + 1).
+        fs::write(batch_dir.join("batch_1.log"), "").unwrap();
+        fs::write(batch_dir.join("batch_3.log"), "").unwrap();
+        fs::write(batch_dir.join("batch_7.log"), "").unwrap();
+
+        temp_env::with_var("ZQA_STATE_DIR", Some(tmp.path()), || {
+            test_eq!(get_seq_id().unwrap(), 8);
+        });
+    }
+
+    #[test]
+    fn metadata_round_trips_with_indices_populated() {
+        let mut meta = make_metadata_at(Utc::now() - Duration::seconds(10), 4);
+        meta.succeeded = Some(vec![0, 2]);
+        meta.failed = Some(vec![1, 3]);
+
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let round_tripped: BatchEmbeddingMetadata = serde_json::from_str(&json).unwrap();
+
+        test_eq!(round_tripped.succeeded.as_deref(), Some(&[0usize, 2][..]));
+        test_eq!(round_tripped.failed.as_deref(), Some(&[1usize, 3][..]));
+        test_eq!(round_tripped.items.len(), 4);
+        test_eq!(round_tripped.batch_id, "bid");
+        test_eq!(round_tripped.provider, ProviderId::VoyageAI);
     }
 
     #[tokio::test]
@@ -969,7 +1090,7 @@ mod tests {
                 assert!(result.is_ok());
 
                 let err = String::from_utf8(ctx.err.into_inner()).unwrap();
-                assert!(err.contains("No valid batches were found"));
+                test_contains!(err, "No valid batches were found");
             },
         )
         .await;

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -25,21 +25,31 @@
 //!   * Files are named `batch_<id>.log`, where `id` are (1-based) sequence numbers to avoid dealing with
 //!     clock drift ([`std::time::SystemTime`] is a fun read for the uninitiated).
 //! * We check the status of batches on startup and when the user explicitly requests it.
-//! * When we check the status of a batch:
+//! * When we check the status of a batch and fetch its results, exactly one of the following applies:
 //!   * If on startup, checking the status reveals a state that is not "submitted" (or that
 //!     provider's lifecycle equivalent), we notify the user, and they decide how to proceed. This
 //!     includes a response indicating that the batch doesn't exist.
-//!   * If the batch has completely failed and there are no successes, we prompt the user to try again.
+//!   * If the provider returns a number of results that does not match the items in our batch file,
+//!     we treat the file as corrupted and surface a hard error. We don't try to partially reconcile.
+//!   * If the batch has completely failed and there are no successes, we prompt the user to try
+//!     again. A retry creates a new batch with the same items (see "retries" below).
 //!   * If the batch has partially succeeded, we notify the user and let them decide. The default
 //!     option here should be to add the processed results to our backend and retry the remaining.
 //!     The user should also have the option to just ignore and retry the whole thing, or pick the
-//!     successes and drop the rest.
+//!     successes and drop the rest. Regardless of choice, successes that are applied flow through
+//!     the hash cache so they aren't re-embedded later.
 //!   * If the batch has completely succeeded, we notify the user only if this check was initiated
-//!     at startup. We add these to our backend and remove this batch.
-//! * Broadly, our semantics resemble a write-ahead log. The files are sorted by creation time, and
-//!   we scan a cache when inserting a batch into the backend to check conflicts (and the newest
-//!   one wins). Moreover, we maintain a cache of hashes (try saying that thrice quickly) with the
-//!   following semantics:
+//!     at startup. We add these to our backend and remove the batch file.
+//! * Retries are *new* batches. Batch IDs are immutable at the provider, and we mirror that on disk:
+//!   a retry submits a fresh request (containing only the items that need re-embedding) and writes
+//!   a new `batch_<id>.log` with its own sequence number. The original file is removed once its
+//!   successes have been applied and the retry has been submitted. This keeps each file a
+//!   self-contained WAL entry rather than a mutable progress log, and means the four-way
+//!   classification above is always a snapshot of one batch — never a merge across runs.
+//! * Broadly, our semantics resemble a write-ahead log. The files are processed in sequence-number
+//!   order, and we scan a cache when inserting a batch into the backend to check conflicts (and
+//!   the newest one wins). Moreover, we maintain a cache of hashes (try saying that thrice
+//!   quickly) with the following semantics:
 //!   * The file is named `.hash_cache`, and is placed in `~/.local/state/zqa/batches`.
 //!   * This file is shared across batches. Shared/exclusive locks to this file preclude other
 //!     file handles from accessing it (this is unlikely, but it is a stronger guarantee than doing
@@ -252,6 +262,7 @@ fn write_batch_metadata(
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 async fn handle_successful_batch_results<O, E>(
     ctx: &mut Context<O, E>,
     batch: &BatchEmbeddingMetadata,

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -69,7 +69,9 @@ use humantime::format_duration;
 use serde::{Deserialize, Serialize};
 use zqa_rag::{
     capabilities::BatchJobState,
-    embedding::common::{BatchEmbeddingInput, BatchEmbeddingRequest, BatchSubmission},
+    embedding::common::{
+        BatchEmbeddingInput, BatchEmbeddingRequest, BatchEmbeddingResult, BatchSubmission,
+    },
     llm::factory::BatchEmbeddingClient,
     providers::{ProviderId, registry::provider_registry},
 };
@@ -250,35 +252,15 @@ fn write_batch_metadata(
     Ok(())
 }
 
-/// Interactively fetch batch results, and update the LanceDB store and the hash cache following the
-/// protocol above.
-#[allow(clippy::too_many_lines)]
-async fn prompt_and_fetch_batch_results<O, E>(
+async fn handle_successful_batch_results<O, E>(
     ctx: &mut Context<O, E>,
-    client: BatchEmbeddingClient,
     batch: &BatchEmbeddingMetadata,
+    successes: &[BatchEmbeddingResult],
 ) -> Result<(), CLIError>
 where
     O: Write,
     E: Write,
 {
-    writeln!(&mut ctx.out, "Fetch results now? ([y]/n)")?;
-    if read_char(&mut io::stdin().lock(), 'y', &['y', 'n']) != 'y' {
-        return Ok(());
-    }
-
-    let batch_id = batch.batch_id.as_str();
-    let results = client.fetch_results(batch_id).await?;
-
-    // TODO: attempt a best-effort match anyway; maybe use a boolean flag or something and handle it
-    // specially later.
-    if results.succeeded.len() + results.failed.len() != batch.items.len() {
-        writeln!(
-            &mut ctx.err,
-            "Length mismatch between batch results and saved batch. The file may have been corrupted."
-        )?;
-    }
-
     let ids_to_items = batch
         .items
         .iter()
@@ -418,8 +400,81 @@ where
     cache_file.write_all(serde_json::to_string_pretty(&overwriteable)?.as_bytes())?;
     cache_file.unlock()?;
 
-    if results.failed.is_empty() {
-        fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
+    Ok(())
+}
+
+/// Interactively fetch batch results, and update the LanceDB store and the hash cache following the
+/// protocol above.
+#[allow(clippy::too_many_lines)]
+async fn prompt_and_fetch_batch_results<O, E>(
+    ctx: &mut Context<O, E>,
+    client: BatchEmbeddingClient,
+    batch: &BatchEmbeddingMetadata,
+) -> Result<(), CLIError>
+where
+    O: Write,
+    E: Write,
+{
+    writeln!(&mut ctx.out, "Fetch results now? ([y]/n)")?;
+    if read_char(&mut io::stdin().lock(), 'y', &['y', 'n']) != 'y' {
+        return Ok(());
+    }
+
+    let batch_id = batch.batch_id.as_str();
+    let results = client.fetch_results(batch_id).await?;
+
+    // TODO: attempt a best-effort match anyway; maybe use a boolean flag or something and handle it
+    // specially later.
+    if results.succeeded.len() + results.failed.len() != batch.items.len() {
+        writeln!(
+            &mut ctx.err,
+            "Length mismatch between batch results and saved batch. The file may have been corrupted."
+        )?;
+    }
+
+    match (results.succeeded.is_empty(), results.failed.is_empty()) {
+        (true, true) => {
+            writeln!(
+                &mut ctx.out,
+                "The batch API did not send any results despite the batch being completed."
+            )?;
+            // TODO: prompt for retry
+        }
+        (true, false) => {
+            // complete failure
+            writeln!(
+                &mut ctx.err,
+                "All {} batch items failed.",
+                results.failed.len()
+            )?;
+
+            for err in results.failed.iter().take(3) {
+                writeln!(&mut ctx.err, "  {} - {}", err.id, err.error)?;
+            }
+
+            writeln!(&mut ctx.out, "Retry the entire batch? ([y]/n)")?;
+            // TODO: implement retry here
+        }
+        (false, true) => {
+            // complete success
+            handle_successful_batch_results(ctx, batch, &results.succeeded).await?;
+
+            let batch_dir = get_state_dir()?.join("batches");
+            if results.failed.is_empty() {
+                fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
+            }
+        }
+        (false, false) => {
+            // partial success
+            writeln!(
+                &mut ctx.out,
+                "{} of {} items succeeded.",
+                results.succeeded.len(),
+                results.succeeded.len() + results.failed.len()
+            )?;
+
+            // TODO: prompt for retry
+        }
     }
 
     Ok(())

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -43,9 +43,11 @@
 //! * Retries are *new* batches. Batch IDs are immutable at the provider, and we mirror that on disk:
 //!   a retry submits a fresh request (containing only the items that need re-embedding) and writes
 //!   a new `batch_<id>.log` with its own sequence number. The original file is removed once its
-//!   successes have been applied and the retry has been submitted. This keeps each file a
-//!   self-contained WAL entry rather than a mutable progress log, and means the four-way
-//!   classification above is always a snapshot of one batch — never a merge across runs.
+//!   successes have been applied and the retry has been submitted. Each file is a self-contained
+//!   record of one batch: `items`, `batch_id`, `provider`, `model`, and `seq_id` are immutable
+//!   once written. The `succeeded` / `failed` index fields are bookkeeping — they may be updated
+//!   in place to record what we've observed about that batch, but the classification is always a
+//!   snapshot of a single fetch, never a merge across runs.
 //! * Broadly, our semantics resemble a write-ahead log. The files are processed in sequence-number
 //!   order, and we scan a cache when inserting a batch into the backend to check conflicts (and
 //!   the newest one wins). Moreover, we maintain a cache of hashes (try saying that thrice
@@ -266,7 +268,7 @@ fn write_batch_metadata(
 async fn handle_successful_batch_results<O, E>(
     ctx: &mut Context<O, E>,
     batch: &BatchEmbeddingMetadata,
-    successes: &[BatchEmbeddingResult],
+    successes: Vec<BatchEmbeddingResult>,
 ) -> Result<(), CLIError>
 where
     O: Write,
@@ -278,7 +280,7 @@ where
         .map(|i| (i.library_key.as_str(), i)) // we use `library_key` as the id in the batch
         .collect::<HashMap<&str, &BatchItem>>();
 
-    let items_to_embeddings: Vec<(&BatchItem, Vec<f32>)> = results.succeeded.into_iter().filter_map(|res| {
+    let items_to_embeddings: Vec<(&BatchItem, Vec<f32>)> = successes.into_iter().filter_map(|res| {
         if let Some(item) = ids_to_items.get(res.id.as_str()) {
             Some((*item, res.embedding))
         } else {
@@ -431,7 +433,7 @@ where
                 "for configuration instructions."
             )
             .into(),
-        ))?;
+        ));
     };
 
     let registry = provider_registry();
@@ -454,7 +456,7 @@ where
             .collect(),
     };
 
-    let submission = embedder.submit_batch(request.clone()).await?;
+    let submission = embedder.submit_batch(request).await?;
     let batch_id = submission.batch_id.clone();
     write_batch_metadata(
         cfg.provider_id(),
@@ -493,20 +495,17 @@ where
         return Err(CLIError::CommandError("Length mismatch between batch results and saved batch. The file may have been corrupted.".into()));
     }
 
+    if batch.items.is_empty() {
+        return Err(CLIError::CommandError(
+            "Cannot fetch the results of an empty batch. This may be due to a corrupted file."
+                .into(),
+        ));
+    }
+
     match (results.succeeded.is_empty(), results.failed.is_empty()) {
         (true, true) => {
-            // no results; this is a strange state to be in, admittedly, so we might handle this
-            // differently in the future
-            writeln!(
-                &mut ctx.out,
-                "The batch API did not send any results despite the batch being completed."
-            )?;
-
-            writeln!(&mut ctx.out, "Do you want to retry? ([y]/n) ")?;
-            if read_char(&mut io::stdin().lock(), 'y', &['y', 'n']) == 'y' {
-                retry_items(ctx, batch.items.clone()).await?;
-                fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
-            }
+            // The checks above early-return with an error
+            unreachable!("Both succeeded and failed batches cannot be empty.");
         }
         (true, false) => {
             // complete failure
@@ -528,7 +527,7 @@ where
         }
         (false, true) => {
             // complete success
-            handle_successful_batch_results(ctx, batch, &results.succeeded).await?;
+            handle_successful_batch_results(ctx, batch, results.succeeded).await?;
 
             fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
         }
@@ -541,8 +540,6 @@ where
                 results.succeeded.len() + results.failed.len()
             )?;
 
-            handle_successful_batch_results(ctx, batch, &results.succeeded).await?;
-
             let ids_to_idx: HashMap<&str, usize> = batch
                 .items
                 .iter()
@@ -550,6 +547,7 @@ where
                 .map(|(i, item)| (item.library_key.as_str(), i))
                 .collect();
 
+            // Collect indices first so we can move later
             let succ_idx: Vec<usize> = results
                 .succeeded
                 .iter()
@@ -561,6 +559,11 @@ where
                 .filter_map(|r| ids_to_idx.get(r.id.as_str()).copied())
                 .collect();
 
+            handle_successful_batch_results(ctx, batch, results.succeeded).await?;
+
+            // Persist the classification so (a) a crash between here and the retry submission
+            // below doesn't lose what we've already applied to the DB, and (b) a future
+            // check-status pass can short-circuit re-fetching once that's implemented.
             let mut batch_metadata = batch.clone();
             batch_metadata.succeeded = Some(succ_idx);
             batch_metadata.failed = Some(failed_idx.clone());

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -414,6 +414,59 @@ where
     Ok(())
 }
 
+/// Given a set of items, submit a batch request based on the configuration in `ctx`, and write the
+/// batch metadata file in the state dir.
+async fn retry_items<O, E>(ctx: &mut Context<O, E>, items: Vec<BatchItem>) -> Result<(), CLIError>
+where
+    O: Write,
+    E: Write,
+{
+    let cfg = ctx.config.get_embedding_config();
+    let Some(cfg) = cfg else {
+        // `CommandError` variants don't exit the CLI
+        return Err(CLIError::CommandError(
+            concat!(
+                "Could not get a config for batch embeddings. Ensure your config has an ",
+                "embedding provider configured. See https://github.com/zotero-rag/zotero-rag#configuration ",
+                "for configuration instructions."
+            )
+            .into(),
+        ))?;
+    };
+
+    let registry = provider_registry();
+    let embedder = match registry.create_batch_embedding(&cfg) {
+        Err(e) => {
+            return Err(CLIError::CommandError(e.to_string()));
+        }
+        Ok(embedder) => embedder,
+    };
+
+    let request = BatchEmbeddingRequest {
+        model: cfg.model_name().into(),
+        dims: cfg.dims(),
+        inputs: items
+            .iter()
+            .map(|item| BatchEmbeddingInput {
+                id: item.library_key.clone(),
+                text: item.text.clone(),
+            })
+            .collect(),
+    };
+
+    let submission = embedder.submit_batch(request.clone()).await?;
+    let batch_id = submission.batch_id.clone();
+    write_batch_metadata(
+        cfg.provider_id(),
+        cfg.model_name().into(),
+        items,
+        submission,
+    )?;
+
+    writeln!(ctx.out, "Batch {batch_id} successfully created.")?;
+    Ok(())
+}
+
 /// Interactively fetch batch results, and update the LanceDB store and the hash cache following the
 /// protocol above.
 #[allow(clippy::too_many_lines)]
@@ -436,20 +489,24 @@ where
     let batch_id = batch.batch_id.as_str();
     let results = client.fetch_results(batch_id).await?;
 
-    // TODO: attempt a best-effort match anyway; maybe use a boolean flag or something and handle it
-    // specially later.
     if results.succeeded.len() + results.failed.len() != batch.items.len() {
         return Err(CLIError::CommandError("Length mismatch between batch results and saved batch. The file may have been corrupted.".into()));
     }
 
     match (results.succeeded.is_empty(), results.failed.is_empty()) {
         (true, true) => {
-            // no results
+            // no results; this is a strange state to be in, admittedly, so we might handle this
+            // differently in the future
             writeln!(
                 &mut ctx.out,
                 "The batch API did not send any results despite the batch being completed."
             )?;
-            // TODO: prompt for retry
+
+            writeln!(&mut ctx.out, "Do you want to retry? ([y]/n) ")?;
+            if read_char(&mut io::stdin().lock(), 'y', &['y', 'n']) == 'y' {
+                retry_items(ctx, batch.items.clone()).await?;
+                fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
+            }
         }
         (true, false) => {
             // complete failure
@@ -464,7 +521,10 @@ where
             }
 
             writeln!(&mut ctx.out, "Retry the entire batch? ([y]/n)")?;
-            // TODO: implement retry here
+            if read_char(&mut io::stdin().lock(), 'y', &['y', 'n']) == 'y' {
+                retry_items(ctx, batch.items.clone()).await?;
+                fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
+            }
         }
         (false, true) => {
             // complete success
@@ -480,8 +540,6 @@ where
                 results.succeeded.len(),
                 results.succeeded.len() + results.failed.len()
             )?;
-
-            // TODO: prompt for retry
 
             handle_successful_batch_results(ctx, batch, &results.succeeded).await?;
 
@@ -505,11 +563,26 @@ where
 
             let mut batch_metadata = batch.clone();
             batch_metadata.succeeded = Some(succ_idx);
-            batch_metadata.failed = Some(failed_idx);
+            batch_metadata.failed = Some(failed_idx.clone());
             fs::write(
                 batch_dir.join(format!("batch_{}.log", batch.seq_id)),
                 serde_json::to_string_pretty(&batch_metadata)?,
             )?;
+
+            // Retry failed items
+            writeln!(
+                &mut ctx.out,
+                "Do you want to retry the failed items? ([y]/n) "
+            )?;
+            if read_char(&mut io::stdin().lock(), 'y', &['y', 'n']) == 'y' {
+                let failed_items: Vec<BatchItem> = failed_idx
+                    .iter()
+                    .filter_map(|i| batch.items.get(*i).cloned())
+                    .collect();
+
+                retry_items(ctx, failed_items).await?;
+                fs::remove_file(batch_dir.join(format!("batch_{}.log", batch.seq_id)))?;
+            }
         }
     }
 
@@ -618,7 +691,6 @@ where
         .await?;
     writeln!(&mut ctx.out, "Current status: {}", status.as_str())?;
 
-    // TODO: For better UX, if this is completed, prompt to fetch, when that subcmd is implemented
     if status == BatchJobState::Completed {
         prompt_and_fetch_batch_results(ctx, embedder, selected_batch).await?;
     }
@@ -643,50 +715,8 @@ where
     };
     let new_items: Vec<BatchItem> = new_items.into_iter().map(Into::into).collect();
 
-    let cfg = ctx.config.get_embedding_config();
-    let Some(cfg) = cfg else {
-        // `CommandError` variants don't exit the CLI
-        return Err(CLIError::CommandError(
-            concat!(
-                "Could not get a config for batch embeddings. Ensure your config has an ",
-                "embedding provider configured. See https://github.com/zotero-rag/zotero-rag#configuration ",
-                "for configuration instructions."
-            )
-            .into(),
-        ))?;
-    };
-
-    let registry = provider_registry();
-    let embedder = match registry.create_batch_embedding(&cfg) {
-        Err(e) => {
-            return Err(CLIError::CommandError(e.to_string()));
-        }
-        Ok(embedder) => embedder,
-    };
-
-    let request = BatchEmbeddingRequest {
-        model: cfg.model_name().into(),
-        dims: cfg.dims(),
-        inputs: new_items
-            .iter()
-            .map(|item| BatchEmbeddingInput {
-                id: item.library_key.clone(),
-                text: item.text.clone(),
-            })
-            .collect(),
-    };
-
-    let submission = embedder.submit_batch(request).await?;
-    let batch_id = submission.batch_id.clone();
-    write_batch_metadata(
-        cfg.provider_id(),
-        cfg.model_name().into(),
-        new_items,
-        submission,
-    )?;
-
-    writeln!(ctx.out, "Batch {batch_id} successfully created.")?;
-    Ok(())
+    // Creating a new batch is equivalent to "retrying" with all items
+    retry_items(ctx, new_items).await
 }
 
 /// Handle the `/batch` commands.


### PR DESCRIPTION
This is the second of two PRs implementing batch API command handlers. The overall goal is to have user-facing commands to interact with batch APIs and allow for retrying failed items. This PR focuses on handling errors and implementing retry logic in an ergonomic way.

Contributes to: ZOT-127