### PR TITLE
feat(rag)!: add metadata table with provider/model info and table version

### DIFF
--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -127,7 +127,7 @@ pub struct LanceMetadata {
     /// last synced to. Under normal operation this equals [`Self::embedding_table_version`];
     /// a difference signals that a write bypassed the metadata sync (or the DB was modified out
     /// of band). See [`LanceBackend::sync_table_version`].
-    stored_data_table_version: u64,
+    data_table_version: u64,
     /// Number of rows in the table
     num_rows: usize,
     /// Embedding provider used
@@ -146,11 +146,11 @@ impl fmt::Display for LanceMetadata {
             "\tEmbedding table version: {}",
             self.embedding_table_version
         )?;
-        if self.stored_data_table_version != self.embedding_table_version {
+        if self.data_table_version != self.embedding_table_version {
             writeln!(
                 f,
                 "\t⚠ metadata last synced at v{} (data table is at v{})",
-                self.stored_data_table_version, self.embedding_table_version
+                self.data_table_version, self.embedding_table_version
             )?;
         }
         writeln!(f, "\tModel provider: {}", self.embedding_provider.as_str())?;
@@ -193,6 +193,29 @@ fn get_initial_metadata(config: &EmbeddingProviderConfig) -> Result<RecordBatch,
     .map_err(LanceError::ArrowError)
 }
 
+/// Ensure that [`LANCE_META_TABLE_NAME`] exists in the database. If it does, no
+/// operation is performed.
+async fn ensure_metadata_table(
+    db: &Connection,
+    config: &EmbeddingProviderConfig,
+) -> Result<(), LanceError> {
+    if !db
+        .table_names()
+        .execute()
+        .await?
+        .contains(&LANCE_META_TABLE_NAME.to_string())
+    {
+        let metadata_record = get_initial_metadata(config)?;
+        db.create_table(LANCE_META_TABLE_NAME, metadata_record)
+            .mode(CreateTableMode::Overwrite)
+            .execute()
+            .await
+            .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+    }
+
+    Ok(())
+}
+
 impl LanceBackend {
     /// Creates a new `LanceBackend` with the given embedding provider config, Arrow schema, and
     /// source column name.
@@ -224,21 +247,7 @@ impl LanceBackend {
     /// Sync the version stored in the metadata table with the data table version. This should be called
     /// after each DB update, including inserts/upserts, version restores, and schema updates.
     async fn sync_table_version(&self, db: &Connection) -> Result<(), LanceError> {
-        if !db
-            .table_names()
-            .execute()
-            .await?
-            .contains(&LANCE_META_TABLE_NAME.to_string())
-        {
-            let metadata_record = get_initial_metadata(&self.config)?;
-            db.create_table(LANCE_META_TABLE_NAME, metadata_record)
-                .mode(CreateTableMode::Overwrite)
-                .execute()
-                .await
-                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
-
-            return Ok(());
-        }
+        ensure_metadata_table(db, &self.config).await?;
 
         let data_tbl = db.open_table(LANCE_DATA_TABLE_NAME).execute().await?;
         let meta_tbl = db.open_table(LANCE_META_TABLE_NAME).execute().await?;
@@ -411,25 +420,38 @@ impl VectorBackend for LanceBackend {
         let embedding_model =
             get_column_from_batch(&batch, MetadataTableColumns::EmbeddingModel.as_str());
 
-        if let Some(provider_string) = embedding_provider.into_iter().next()
-            && let Ok(provider) = ProviderId::from_str(&provider_string)
-            && let Some(model) = embedding_model.into_iter().next()
-        {
-            Ok(LanceMetadata {
-                num_tables,
-                num_rows,
-                embedding_table_version: table_version,
-                stored_data_table_version,
-                embedding_provider: provider,
-                embedding_model: model,
-            })
-        } else {
-            // TODO: This isn't a useful error message for *users*, it tells them nothing about what
-            // to do; although, there isn't much they can...
+        let Some(provider_string) = embedding_provider.into_iter().last() else {
             return Err(LanceError::InvalidStateError(format!(
-                "We got a batch from {LANCE_META_TABLE_NAME}, but the metadata columns were empty."
+                "We got a batch from {LANCE_META_TABLE_NAME}, but the {} column was empty.",
+                MetadataTableColumns::EmbeddingProvider.as_str()
             )));
-        }
+        };
+
+        let Ok(provider) = ProviderId::from_str(&provider_string) else {
+            return Err(LanceError::InvalidStateError(format!(
+                concat!(
+                    "The provider in the metadata table '{}' is not valid. ",
+                    "Either the database is corrupted, or the database was created with a newer version."
+                ),
+                provider_string
+            )));
+        };
+
+        let Some(model) = embedding_model.into_iter().next() else {
+            return Err(LanceError::InvalidStateError(format!(
+                "We got a batch from {LANCE_META_TABLE_NAME}, but the {} column was empty.",
+                MetadataTableColumns::EmbeddingModel.as_str()
+            )));
+        };
+
+        Ok(LanceMetadata {
+            num_tables,
+            num_rows,
+            embedding_table_version: table_version,
+            data_table_version,
+            embedding_provider: provider,
+            embedding_model: model,
+        })
     }
 
     /// Checks if an existing LanceDB exists and has a valid table
@@ -611,8 +633,6 @@ impl VectorBackend for LanceBackend {
         if !duplicate_keys.is_empty() {
             self.delete_rows(key, &duplicate_keys).await?;
         }
-
-        self.sync_table_version(&db).await?;
 
         Ok(deleted_count)
     }
@@ -915,7 +935,7 @@ impl VectorBackend for LanceBackend {
             //
             // If the metadata is stored and creating the data table fails,
             // [`CreateTableMode::Overwrite`] overwrites it on the next attempt anyway.
-            self.sync_table_version(&db).await?;
+            ensure_metadata_table(&db, &self.config).await?;
 
             // Create a new table and add rows
             db.create_table(LANCE_DATA_TABLE_NAME, items)
@@ -924,6 +944,8 @@ impl VectorBackend for LanceBackend {
                 .execute()
                 .await
                 .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+
+            self.sync_table_version(&db).await?;
         }
 
         Ok(())
@@ -1043,7 +1065,10 @@ mod tests {
 
         let tbl_names = conn.table_names().execute().await;
         test_ok!(tbl_names);
-        test_eq!(tbl_names.unwrap(), vec![LANCE_DATA_TABLE_NAME]);
+        test_eq!(
+            tbl_names.unwrap(),
+            vec![LANCE_DATA_TABLE_NAME, LANCE_META_TABLE_NAME]
+        );
 
         let tbl = conn.open_table(LANCE_DATA_TABLE_NAME).execute().await;
         test_ok!(tbl);
@@ -1142,7 +1167,7 @@ mod tests {
 
         // Freshly created: metadata is in sync with the live data table version, no warning shown.
         let meta = backend.get_metadata().await.unwrap();
-        test_eq!(meta.stored_data_table_version, meta.embedding_table_version);
+        test_eq!(meta.data_table_version, meta.embedding_table_version);
         assert!(
             !format!("{meta}").contains("metadata last synced at"),
             "in-sync metadata should not render a drift warning"
@@ -1160,10 +1185,10 @@ mod tests {
 
         let meta = backend.get_metadata().await.unwrap();
         assert!(
-            meta.embedding_table_version > meta.stored_data_table_version,
+            meta.embedding_table_version > meta.data_table_version,
             "expected live version {} to exceed stored {}",
             meta.embedding_table_version,
-            meta.stored_data_table_version
+            meta.data_table_version
         );
         assert!(
             format!("{meta}").contains("metadata last synced at"),

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -437,7 +437,7 @@ impl VectorBackend for LanceBackend {
             )));
         };
 
-        let Some(model) = embedding_model.into_iter().next() else {
+        let Some(model) = embedding_model.into_iter().last() else {
             return Err(LanceError::InvalidStateError(format!(
                 "We got a batch from {LANCE_META_TABLE_NAME}, but the {} column was empty.",
                 MetadataTableColumns::EmbeddingModel.as_str()

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -26,7 +26,7 @@ use crate::{
     vector::backends::backend::VectorBackend,
 };
 
-// NOTE: Maintainers: ensure that `LANCEDB_URI` begins with `LANCE_TABLE_NAME`
+// NOTE: Maintainers: ensure that `LANCEDB_URI` begins with `LANCE_DATA_TABLE_NAME`
 
 /// The URI for the LanceDB table. This is the default location for the table, and for now cannot
 /// be changed.
@@ -37,7 +37,7 @@ pub const LANCEDB_URI: &str = "data/lancedb-table";
 pub const LANCE_DATA_TABLE_NAME: &str = "data";
 /// The name of the table containing metadata (model provider, model string, etc.). Like
 /// [`LANCE_DATA_TABLE_NAME`], this also cannot be changed for now.
-pub const LANCE_META_TABLE_NAME: &str = "data";
+pub const LANCE_META_TABLE_NAME: &str = "metadata";
 
 /// Enum of columns maintained in the LanceDB metadata table.
 enum MetadataTableColumns {
@@ -55,15 +55,6 @@ impl MetadataTableColumns {
             Self::DataTableVersion => "data_table_version",
             Self::EmbeddingProvider => "embedding_provider",
             Self::EmbeddingModel => "embedding_model",
-        }
-    }
-
-    fn column_number(&self) -> usize {
-        match self {
-            Self::LibVersion => 0,
-            Self::DataTableVersion => 1,
-            Self::EmbeddingProvider => 2,
-            Self::EmbeddingModel => 3,
         }
     }
 }
@@ -158,7 +149,7 @@ impl fmt::Display for LanceMetadata {
                 "LanceDB metadata:\n",
                 "\tNumber of tables: {}\n",
                 "\tNumber of rows: {}\n",
-                "\tEmbedding table version: {}",
+                "\tEmbedding table version: {}\n",
                 "\tModel provider: {}\n",
                 "\tModel: {}\n",
             ),
@@ -189,7 +180,7 @@ fn get_initial_metadata(config: &EmbeddingProviderConfig) -> Result<RecordBatch,
         // This lets us allow switching models, which is on the roadmap anyway
         (
             MetadataTableColumns::DataTableVersion.as_str(),
-            Int32,
+            Int64,
             [1] // LanceDB tables start at version 1
         ),
         (
@@ -227,7 +218,6 @@ impl LanceBackend {
     /// Sync the version stored in the metadata table with the data table version. This should be called
     /// after each DB update, including inserts/upserts, version restores, and schema updates.
     async fn sync_table_version(&self, db: &Connection) -> Result<(), LanceError> {
-        let data_tbl = db.open_table(LANCE_DATA_TABLE_NAME).execute().await?;
         if !db
             .table_names()
             .execute()
@@ -244,6 +234,7 @@ impl LanceBackend {
             return Ok(());
         }
 
+        let data_tbl = db.open_table(LANCE_DATA_TABLE_NAME).execute().await?;
         let meta_tbl = db.open_table(LANCE_META_TABLE_NAME).execute().await?;
 
         let new_version = data_tbl.version().await?;
@@ -251,7 +242,7 @@ impl LanceBackend {
             .update()
             .column(
                 MetadataTableColumns::DataTableVersion,
-                format!("{new_version} + 1"),
+                new_version.to_string(),
             )
             .execute()
             .await?;
@@ -260,19 +251,25 @@ impl LanceBackend {
     }
 }
 
-/// From a `RecordBatch`, return all values from a specified column as a `Vec<String>`.
+/// From a `RecordBatch`, return all values from the named column as a `Vec<String>`.
 ///
 /// # Arguments
 ///
 /// * `batch`: A reference to a `RecordBatch`.
-/// * `column`: The index of the column to use.
+/// * `column`: The name of the column to use.
 ///
 /// # Returns
 ///
-/// A `Vec<String>` containing all the items in the specified column of the `RecordBatch`.
+/// A `Vec<String>` containing all the items in the named column of the `RecordBatch`. Returns an
+/// empty `Vec` if the column does not exist or is not a UTF-8 string column.
 #[must_use]
-fn get_column_from_batch(batch: &RecordBatch, column: usize) -> Vec<String> {
-    let results = batch.column(column).as_string::<i32>();
+fn get_column_from_batch(batch: &RecordBatch, column: &str) -> Vec<String> {
+    let Some(array) = batch.column_by_name(column) else {
+        return Vec::new();
+    };
+    let Some(results) = array.as_string_opt::<i32>() else {
+        return Vec::new();
+    };
 
     results
         .iter()
@@ -336,7 +333,7 @@ impl VectorBackend for LanceBackend {
             .await
             .map_err(|_| {
                 LanceError::InvalidStateError(format!(
-                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
+                    "The table {LANCE_META_TABLE_NAME} does not exist"
                 ))
             })?;
         let mut stream = meta_tbl.query().execute().await?;
@@ -346,12 +343,10 @@ impl VectorBackend for LanceBackend {
             )));
         };
 
-        let embedding_provider = get_column_from_batch(
-            &batch,
-            MetadataTableColumns::EmbeddingProvider.column_number(),
-        );
+        let embedding_provider =
+            get_column_from_batch(&batch, MetadataTableColumns::EmbeddingProvider.as_str());
         let embedding_model =
-            get_column_from_batch(&batch, MetadataTableColumns::EmbeddingModel.column_number());
+            get_column_from_batch(&batch, MetadataTableColumns::EmbeddingModel.as_str());
 
         if let Some(provider_string) = embedding_provider.into_iter().next()
             && let Ok(provider) = ProviderId::from_str(&provider_string)
@@ -528,16 +523,8 @@ impl VectorBackend for LanceBackend {
         let mut duplicate_keys = Vec::new();
 
         while let Some(batch) = stream.try_next().await? {
-            let batch_schema = batch.schema();
-            let Some((by_idx, _)) = batch_schema.column_with_name(by) else {
-                continue;
-            };
-            let Some((key_idx, _)) = batch_schema.column_with_name(key) else {
-                continue;
-            };
-
-            let by_values = get_column_from_batch(&batch, by_idx);
-            let key_values = get_column_from_batch(&batch, key_idx);
+            let by_values = get_column_from_batch(&batch, by);
+            let key_values = get_column_from_batch(&batch, key);
 
             for (by_val, key_val) in by_values.into_iter().zip(key_values) {
                 if !seen_by_values.insert(by_val) {
@@ -839,6 +826,8 @@ impl VectorBackend for LanceBackend {
                 .execute(Box::new(reader))
                 .await
                 .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+
+            self.sync_table_version(&db).await?;
         } else {
             let embedding_params = EmbeddingDefinition::new(
                 self.source_col.as_str(),

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -253,6 +253,10 @@ impl LanceBackend {
         let meta_tbl = db.open_table(LANCE_META_TABLE_NAME).execute().await?;
 
         let new_version = data_tbl.version().await?;
+
+        // NOTE: If we migrate to a design where we use multiple rows (e.g., if we want to allow
+        // different versions with different models/providers/etc.), then an `only_if` should be
+        // added here.
         meta_tbl
             .update()
             .column(
@@ -319,7 +323,7 @@ fn stored_version_from_batch(batch: &RecordBatch) -> Result<u64, LanceError> {
         )));
     }
 
-    u64::try_from(values.value(0)).map_err(|_| {
+    u64::try_from(values.value(values.len() - 1)).map_err(|_| {
         LanceError::InvalidStateError(format!(
             "The stored data table version ({}) is negative",
             values.value(0)

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -171,6 +171,41 @@ impl fmt::Display for LanceMetadata {
     }
 }
 
+/// Get the database metadata for a newly-created DB. This data is stored in
+/// [`LANCE_META_TABLE_NAME`] and updated on operations that modify the data table version.
+fn get_initial_metadata(config: &EmbeddingProviderConfig) -> Result<RecordBatch, LanceError> {
+    // LanceDB allows useful operations such as schema updates, and each of those is
+    // associated with a new table version. In the future, we might switch to a different
+    // schema, such as with different types (which LanceDB also supports); in this case,
+    // recording a minimum supported lib version is necessary.
+    let lib_version = env!("CARGO_PKG_VERSION");
+
+    record_batch!(
+        (
+            MetadataTableColumns::LibVersion.as_str(),
+            Utf8,
+            [lib_version]
+        ),
+        // This lets us allow switching models, which is on the roadmap anyway
+        (
+            MetadataTableColumns::DataTableVersion.as_str(),
+            Int32,
+            [1] // LanceDB tables start at version 1
+        ),
+        (
+            MetadataTableColumns::EmbeddingProvider.as_str(),
+            Utf8,
+            [config.provider_id().as_str()]
+        ),
+        (
+            MetadataTableColumns::EmbeddingModel.as_str(),
+            Utf8,
+            [config.model_name()]
+        )
+    )
+    .map_err(LanceError::ArrowError)
+}
+
 impl LanceBackend {
     /// Creates a new `LanceBackend` with the given embedding provider config, Arrow schema, and
     /// source column name.
@@ -187,6 +222,41 @@ impl LanceBackend {
     #[must_use]
     pub fn embedding_config(&self) -> &EmbeddingProviderConfig {
         &self.config
+    }
+
+    /// Sync the version stored in the metadata table with the data table version. This should be called
+    /// after each DB update, including inserts/upserts, version restores, and schema updates.
+    async fn sync_table_version(&self, db: &Connection) -> Result<(), LanceError> {
+        let data_tbl = db.open_table(LANCE_DATA_TABLE_NAME).execute().await?;
+        if !db
+            .table_names()
+            .execute()
+            .await?
+            .contains(&LANCE_META_TABLE_NAME.to_string())
+        {
+            let metadata_record = get_initial_metadata(&self.config)?;
+            db.create_table(LANCE_META_TABLE_NAME, metadata_record)
+                .mode(CreateTableMode::Overwrite)
+                .execute()
+                .await
+                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+
+            return Ok(());
+        }
+
+        let meta_tbl = db.open_table(LANCE_META_TABLE_NAME).execute().await?;
+
+        let new_version = data_tbl.version().await?;
+        meta_tbl
+            .update()
+            .column(
+                MetadataTableColumns::DataTableVersion,
+                format!("{new_version} + 1"),
+            )
+            .execute()
+            .await?;
+
+        Ok(())
     }
 }
 
@@ -208,27 +278,6 @@ fn get_column_from_batch(batch: &RecordBatch, column: usize) -> Vec<String> {
         .iter()
         .filter_map(|s| Some(s?.to_string()))
         .collect()
-}
-
-// TODO: Implement a `migrate` function to migrate to a new DB version
-
-/// Sync the version stored in the metadata table with the data table version. This should be called
-/// after each DB update, including inserts/upserts, version restores, and schema updates.
-async fn sync_table_version(db: &Connection) -> Result<(), LanceError> {
-    let data_tbl = db.open_table(LANCE_DATA_TABLE_NAME).execute().await?;
-    let meta_tbl = db.open_table(LANCE_META_TABLE_NAME).execute().await?;
-
-    let new_version = data_tbl.version().await?;
-    meta_tbl
-        .update()
-        .column(
-            MetadataTableColumns::DataTableVersion,
-            format!("{new_version} + 1"),
-        )
-        .execute()
-        .await?;
-
-    Ok(())
 }
 
 #[async_trait]
@@ -371,7 +420,7 @@ impl VectorBackend for LanceBackend {
             .await?;
         }
 
-        sync_table_version(&db).await?;
+        self.sync_table_version(&db).await?;
 
         // If both indices already existed before this run, they could be optimized here
         // but optimization is optional and can be done separately.
@@ -431,7 +480,7 @@ impl VectorBackend for LanceBackend {
             table.delete(&delete_pred).await?;
         }
 
-        sync_table_version(&db).await?;
+        self.sync_table_version(&db).await?;
 
         Ok(())
     }
@@ -503,7 +552,7 @@ impl VectorBackend for LanceBackend {
             self.delete_rows(key, &duplicate_keys).await?;
         }
 
-        sync_table_version(&db).await?;
+        self.sync_table_version(&db).await?;
 
         Ok(deleted_count)
     }
@@ -797,35 +846,6 @@ impl VectorBackend for LanceBackend {
                 Some("embeddings"),
             );
 
-            // LanceDB allows useful operations such as schema updates, and each of those is
-            // associated with a new table version. In the future, we might switch to a different
-            // schema, such as with different types (which LanceDB also supports); in this case,
-            // recording a minimum supported lib version is necessary.
-            let lib_version = env!("CARGO_PKG_VERSION");
-            let metadata_record = record_batch!(
-                (
-                    MetadataTableColumns::LibVersion.as_str(),
-                    Utf8,
-                    [lib_version]
-                ),
-                // This lets us allow switching models, which is on the roadmap anyway
-                (
-                    MetadataTableColumns::DataTableVersion.as_str(),
-                    Int32,
-                    [1] // LanceDB tables start at version 1
-                ),
-                (
-                    MetadataTableColumns::EmbeddingProvider.as_str(),
-                    Utf8,
-                    [self.config.provider_id().as_str()]
-                ),
-                (
-                    MetadataTableColumns::EmbeddingModel.as_str(),
-                    Utf8,
-                    [self.config.model_name()]
-                )
-            )?;
-
             // Create the metadata table first. This order guarantees that in the worst case, we
             // end up with a DB that knows which provider is being used and has no data; the
             // alternative would be a DB that has data but does not "know" what model/provider were
@@ -833,11 +853,7 @@ impl VectorBackend for LanceBackend {
             //
             // If the metadata is stored and creating the data table fails,
             // [`CreateTableMode::Overwrite`] overwrites it on the next attempt anyway.
-            db.create_table(LANCE_META_TABLE_NAME, metadata_record)
-                .mode(CreateTableMode::Overwrite)
-                .execute()
-                .await
-                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+            self.sync_table_version(&db).await?;
 
             // Create a new table and add rows
             db.create_table(LANCE_DATA_TABLE_NAME, items)
@@ -847,8 +863,6 @@ impl VectorBackend for LanceBackend {
                 .await
                 .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
         }
-
-        sync_table_version(&db).await?;
 
         Ok(())
     }

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -414,7 +414,7 @@ impl VectorBackend for LanceBackend {
             )));
         };
 
-        let stored_data_table_version = stored_version_from_batch(&batch)?;
+        let data_table_version = stored_version_from_batch(&batch)?;
         let embedding_provider =
             get_column_from_batch(&batch, MetadataTableColumns::EmbeddingProvider.as_str());
         let embedding_model =

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -101,20 +101,6 @@ pub fn get_db_uri() -> String {
     std::env::var("LANCEDB_URI").unwrap_or_else(|_| LANCEDB_URI.to_string())
 }
 
-/// Checks whether the configured LanceDB database exists and contains the expected table.
-async fn db_exists() -> bool {
-    let uri = get_db_uri();
-    if !PathBuf::from(&uri).exists() {
-        return false;
-    }
-
-    if let Ok(db) = connect(&uri).execute().await {
-        db.open_table(LANCE_DATA_TABLE_NAME).execute().await.is_ok()
-    } else {
-        false
-    }
-}
-
 /// Backend for LanceDB vector store.
 #[derive(Debug, Clone)]
 pub struct LanceBackend {
@@ -124,6 +110,9 @@ pub struct LanceBackend {
     schema: Arc<Schema>,
     /// Column name containing the source text used to generate embeddings.
     source_col: String,
+    /// Override for the database URI. When `None`, the URI falls back to the `LANCEDB_URI`
+    /// environment variable (or the [`LANCEDB_URI`] default) via [`get_db_uri`].
+    uri: Option<String>,
 }
 
 /// Metadata about the LanceDB database.
@@ -206,7 +195,17 @@ impl LanceBackend {
             config,
             schema,
             source_col,
+            uri: None,
         }
+    }
+
+    /// Overrides the database URI for this backend instance. When unset, the URI falls back to the
+    /// `LANCEDB_URI` environment variable (or the [`LANCEDB_URI`] default). This is primarily useful
+    /// for pointing a backend at an isolated location, such as a temporary directory in tests.
+    #[must_use]
+    pub fn with_uri(mut self, uri: impl Into<String>) -> Self {
+        self.uri = Some(uri.into());
+        self
     }
 
     /// Returns a reference to the embedding provider configuration.
@@ -287,9 +286,11 @@ impl VectorBackend for LanceBackend {
     type Connection = lancedb::Connection;
     type Metadata = LanceMetadata;
 
-    /// Returns the database URI, allowing override via `LANCEDB_URI` environment variable.
+    /// Returns the database URI for this backend, preferring an instance override (see
+    /// [`LanceBackend::with_uri`]) and otherwise falling back to the `LANCEDB_URI` environment
+    /// variable.
     fn get_db_path(&self) -> String {
-        get_db_uri()
+        self.uri.clone().unwrap_or_else(get_db_uri)
     }
 
     async fn get_metadata(&self) -> Result<Self::Metadata, Self::Error> {
@@ -370,7 +371,16 @@ impl VectorBackend for LanceBackend {
 
     /// Checks if an existing LanceDB exists and has a valid table
     async fn db_exists(&self) -> bool {
-        db_exists().await
+        let uri = self.get_db_path();
+        if !PathBuf::from(&uri).exists() {
+            return false;
+        }
+
+        if let Ok(db) = connect(&uri).execute().await {
+            db.open_table(LANCE_DATA_TABLE_NAME).execute().await.is_ok()
+        } else {
+            false
+        }
     }
 
     /// Create indices for the database. This function creates two indices: an IVF-PQ index on the
@@ -871,7 +881,6 @@ mod tests {
     use futures::StreamExt;
     use lancedb::embeddings::EmbeddingFunction;
     use lancedb::query::ExecutableQuery;
-    use serial_test::serial;
     use zqa_macros::{test_eq, test_ok};
     use zqa_pdftools::chunk::Chunker;
 
@@ -904,18 +913,33 @@ mod tests {
         )])
     }
 
-    fn get_backend(source_col: &str, config: EmbeddingProviderConfig) -> LanceBackend {
+    /// Creates an isolated, uniquely-named temporary database location. The returned [`TempDir`]
+    /// guard must be kept alive for the duration of the test; dropping it deletes the database.
+    /// Because each backend is pointed at its own directory via [`LanceBackend::with_uri`], these
+    /// tests are fully isolated and need no shared-state serialization (no `#[serial]`).
+    fn temp_db() -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir
+            .path()
+            .join("lancedb-table")
+            .to_str()
+            .unwrap()
+            .to_string();
+        (dir, uri)
+    }
+
+    fn get_backend(source_col: &str, config: EmbeddingProviderConfig, uri: &str) -> LanceBackend {
         let schema = get_schema(source_col);
 
-        LanceBackend::new(config, Arc::new(schema), source_col.into())
+        LanceBackend::new(config, Arc::new(schema), source_col.into()).with_uri(uri)
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_create_initial_table_with_openai() {
         dotenv().ok();
 
-        let backend = get_backend("data_openai", get_test_openai_embedding_config());
+        let (_db_dir, uri) = temp_db();
+        let backend = get_backend("data_openai", get_test_openai_embedding_config(), &uri);
         let data = StringArray::from(vec!["Hello", "World"]);
 
         let record_batch =
@@ -928,11 +952,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_create_initial_table_with_voyage() {
         dotenv().ok();
 
         let schema = get_schema("data_voyage");
+        let (_db_dir, uri) = temp_db();
         let backend = get_backend(
             "data_voyage",
             EmbeddingProviderConfig::VoyageAI(VoyageAIConfig {
@@ -941,6 +965,7 @@ mod tests {
                 api_key: env::var("VOYAGE_AI_API_KEY").unwrap(),
                 reranker: DEFAULT_VOYAGE_RERANK_MODEL.into(),
             }),
+            &uri,
         );
         let data = StringArray::from(vec!["Hello", "World"]);
         let record_batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(data)]).unwrap();
@@ -979,8 +1004,56 @@ mod tests {
         }
     }
 
+    /// Locks in the canonical metadata-table schema: a freshly-created DB must have a metadata
+    /// table whose columns are exactly these, in exactly this order. Changing the metadata
+    /// schema is a deliberate act; maintainers should update `get_initial_metadata` and the
+    /// canonical order below together.
     #[tokio::test]
-    #[serial]
+    async fn test_metadata_table_has_canonical_columns() {
+        dotenv().ok();
+
+        let (_db_dir, uri) = temp_db();
+        let backend = get_backend("data_openai", get_test_openai_embedding_config(), &uri);
+        let data = StringArray::from(vec!["Hello", "World"]);
+        let record_batch =
+            RecordBatch::try_new(Arc::new(get_schema("data_openai")), vec![Arc::new(data)])
+                .unwrap();
+        backend
+            .insert_items(vec![record_batch], None)
+            .await
+            .expect("Failed to create new DB");
+
+        let db = backend.connect().await.expect("Failed to connect");
+        let meta_tbl = db
+            .open_table(LANCE_META_TABLE_NAME)
+            .execute()
+            .await
+            .expect("Metadata table should exist after DB creation");
+        let schema = meta_tbl
+            .schema()
+            .await
+            .expect("Failed to read metadata table schema");
+
+        let columns = schema
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect::<Vec<_>>();
+
+        let expected: Vec<String> = [
+            MetadataTableColumns::LibVersion,
+            MetadataTableColumns::DataTableVersion,
+            MetadataTableColumns::EmbeddingProvider,
+            MetadataTableColumns::EmbeddingModel,
+        ]
+        .iter()
+        .map(|col| col.as_str().to_string())
+        .collect();
+
+        test_eq!(columns, expected);
+    }
+
+    #[tokio::test]
     async fn test_search_by_key() {
         dotenv().ok();
 
@@ -999,7 +1072,9 @@ mod tests {
         let batches = vec![record_batch];
 
         let embedding_config = get_test_openai_embedding_config();
-        let backend = LanceBackend::new(embedding_config, schema, "content".into());
+        let (_db_dir, uri) = temp_db();
+        let backend =
+            LanceBackend::new(embedding_config, schema, "content".into()).with_uri(uri.as_str());
 
         backend.insert_items(batches, None).await.unwrap();
 
@@ -1026,7 +1101,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_search_by_column() {
         dotenv().ok();
 
@@ -1044,7 +1118,9 @@ mod tests {
         .unwrap();
 
         let embedding_config = get_test_openai_embedding_config();
-        let backend = LanceBackend::new(embedding_config, schema, "item".into());
+        let (_db_dir, uri) = temp_db();
+        let backend =
+            LanceBackend::new(embedding_config, schema, "item".into()).with_uri(uri.as_str());
         backend
             .insert_items(vec![record_batch], None)
             .await
@@ -1089,7 +1165,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_create_or_update_indexes() {
         dotenv().ok();
 
@@ -1108,7 +1183,9 @@ mod tests {
                 .unwrap();
 
         let embedding_config = get_test_openai_embedding_config();
-        let backend = LanceBackend::new(embedding_config, schema, "text".into());
+        let (_db_dir, uri) = temp_db();
+        let backend =
+            LanceBackend::new(embedding_config, schema, "text".into()).with_uri(uri.as_str());
         backend
             .insert_items(vec![record_batch], None)
             .await
@@ -1124,7 +1201,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_dedup_rows_removes_duplicates() {
         dotenv().ok();
 
@@ -1142,7 +1218,9 @@ mod tests {
         .unwrap();
 
         let embedding_config = get_test_openai_embedding_config();
-        let backend = LanceBackend::new(embedding_config, schema, "title".into());
+        let (_db_dir, uri) = temp_db();
+        let backend =
+            LanceBackend::new(embedding_config, schema, "title".into()).with_uri(uri.as_str());
         backend
             .insert_items(vec![record_batch], None)
             .await
@@ -1159,7 +1237,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_dedup_rows_no_duplicates() {
         dotenv().ok();
 
@@ -1176,7 +1253,9 @@ mod tests {
         .unwrap();
 
         let embedding_config = get_test_openai_embedding_config();
-        let backend = LanceBackend::new(embedding_config, schema, "title".into());
+        let (_db_dir, uri) = temp_db();
+        let backend =
+            LanceBackend::new(embedding_config, schema, "title".into()).with_uri(uri.as_str());
         backend
             .insert_items(vec![record_batch], None)
             .await
@@ -1188,7 +1267,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_dedup_rows_missing_columns_returns_zero() {
         dotenv().ok();
 
@@ -1205,7 +1283,9 @@ mod tests {
         .unwrap();
 
         let embedding_config = get_test_openai_embedding_config();
-        let insert_backend = LanceBackend::new(embedding_config.clone(), schema, "title".into());
+        let (_db_dir, uri) = temp_db();
+        let insert_backend = LanceBackend::new(embedding_config.clone(), schema, "title".into())
+            .with_uri(uri.as_str());
         insert_backend
             .insert_items(vec![record_batch], None)
             .await
@@ -1217,7 +1297,8 @@ mod tests {
             arrow_schema::Field::new("nonexistent_by", arrow_schema::DataType::Utf8, false),
             arrow_schema::Field::new("nonexistent_key", arrow_schema::DataType::Utf8, false),
         ]));
-        let backend = LanceBackend::new(embedding_config, missing_schema, "nonexistent_by".into());
+        let backend = LanceBackend::new(embedding_config, missing_schema, "nonexistent_by".into())
+            .with_uri(uri.as_str());
         let deleted = backend
             .dedup_rows("nonexistent_by", "nonexistent_key")
             .await;
@@ -1232,7 +1313,6 @@ mod tests {
     /// Verify that a real PDF is chunked into non-empty, well-formed chunks using the
     /// OpenAI-recommended strategy.
     #[tokio::test]
-    #[serial]
     async fn test_pdf_chunking_with_openai_strategy() {
         let extracted =
             zqa_pdftools::parse::extract_text(&pdf_asset_path()).expect("Failed to parse PDF");
@@ -1274,7 +1354,6 @@ mod tests {
     /// Verify that chunks from a real PDF can be embedded with OpenAI and that the resulting
     /// vectors are non-zero.
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn test_pdf_chunk_embeddings_are_non_zero() {
         dotenv().ok();
 
@@ -1328,7 +1407,6 @@ mod tests {
     /// document, then verify that a query matching the sentinel retrieves it as the top result
     /// rather than a PDF chunk.
     #[tokio::test(flavor = "multi_thread")]
-    #[serial]
     async fn test_retrieval_ranks_relevant_content_higher() {
         dotenv().ok();
 
@@ -1369,6 +1447,7 @@ mod tests {
         .unwrap();
 
         let embedding_config = get_test_openai_embedding_config();
+        let (_db_dir, uri) = temp_db();
         let backend = LanceBackend::new(
             embedding_config,
             Arc::new(arrow_schema::Schema::new(vec![
@@ -1376,7 +1455,8 @@ mod tests {
                 arrow_schema::Field::new("text", arrow_schema::DataType::Utf8, false),
             ])),
             "text".into(),
-        );
+        )
+        .with_uri(uri.as_str());
         backend
             .insert_items(vec![record_batch], None)
             .await

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -3,21 +3,24 @@
 use core::fmt;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::Float32Type;
-use arrow_array::{RecordBatch, RecordBatchIterator, StringArray};
+use arrow_array::{RecordBatch, RecordBatchIterator, StringArray, record_batch};
 use arrow_schema::{ArrowError, Schema};
 use async_trait::async_trait;
 use futures::TryStreamExt;
+use lancedb::Connection;
 use lancedb::database::CreateTableMode;
 use lancedb::embeddings::EmbeddingDefinition;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::{Error as LanceDbError, connect, index::scalar::FtsIndexBuilder};
 use thiserror::Error;
 
+use crate::providers::ProviderId;
 use crate::{
     embedding::common::EmbeddingProviderConfig, providers::registry::provider_registry,
     vector::backends::backend::VectorBackend,
@@ -29,8 +32,47 @@ use crate::{
 /// be changed.
 pub const LANCEDB_URI: &str = "data/lancedb-table";
 
-/// The name of the table. This is the default table name, and for now cannot be changed.
-pub const LANCE_TABLE_NAME: &str = "data";
+/// The name of the table containing data (passages, embeddings, etc.) This is the default table
+/// name, and for now cannot be changed.
+pub const LANCE_DATA_TABLE_NAME: &str = "data";
+/// The name of the table containing metadata (model provider, model string, etc.). Like
+/// [`LANCE_DATA_TABLE_NAME`], this also cannot be changed for now.
+pub const LANCE_META_TABLE_NAME: &str = "data";
+
+/// Enum of columns maintained in the LanceDB metadata table.
+enum MetadataTableColumns {
+    LibVersion,
+    DataTableVersion,
+    EmbeddingProvider,
+    EmbeddingModel,
+}
+
+impl MetadataTableColumns {
+    /// Return the in-table column name for this enum variant.
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::LibVersion => "zqa_rag_version",
+            Self::DataTableVersion => "data_table_version",
+            Self::EmbeddingProvider => "embedding_provider",
+            Self::EmbeddingModel => "embedding_model",
+        }
+    }
+
+    fn column_number(&self) -> usize {
+        match self {
+            Self::LibVersion => 0,
+            Self::DataTableVersion => 1,
+            Self::EmbeddingProvider => 2,
+            Self::EmbeddingModel => 3,
+        }
+    }
+}
+
+impl From<MetadataTableColumns> for String {
+    fn from(val: MetadataTableColumns) -> Self {
+        val.as_str().into()
+    }
+}
 
 /// Errors that can occur when working with LanceDB
 #[derive(Debug, Error)]
@@ -69,14 +111,14 @@ pub fn get_db_uri() -> String {
 }
 
 /// Checks whether the configured LanceDB database exists and contains the expected table.
-pub async fn db_exists() -> bool {
+async fn db_exists() -> bool {
     let uri = get_db_uri();
     if !PathBuf::from(&uri).exists() {
         return false;
     }
 
     if let Ok(db) = connect(&uri).execute().await {
-        db.open_table(LANCE_TABLE_NAME).execute().await.is_ok()
+        db.open_table(LANCE_DATA_TABLE_NAME).execute().await.is_ok()
     } else {
         false
     }
@@ -102,14 +144,29 @@ pub struct LanceMetadata {
     embedding_table_version: u64,
     /// Number of rows in the table
     num_rows: usize,
+    /// Embedding provider used
+    embedding_provider: ProviderId,
+    /// Embedding model
+    embedding_model: String,
 }
 
 impl fmt::Display for LanceMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "LanceDB Statistics:\n\tNumber of tables: {}\n\tNumber of rows: {}\n\tEmbedding table version: {}",
-            self.num_tables, self.num_rows, self.embedding_table_version
+            concat!(
+                "LanceDB metadata:\n",
+                "\tNumber of tables: {}\n",
+                "\tNumber of rows: {}\n",
+                "\tEmbedding table version: {}",
+                "\tModel provider: {}\n",
+                "\tModel: {}\n",
+            ),
+            self.num_tables,
+            self.num_rows,
+            self.embedding_table_version,
+            self.embedding_provider.as_str(),
+            self.embedding_model
         )
     }
 }
@@ -144,13 +201,34 @@ impl LanceBackend {
 ///
 /// A `Vec<String>` containing all the items in the specified column of the `RecordBatch`.
 #[must_use]
-pub fn get_column_from_batch(batch: &RecordBatch, column: usize) -> Vec<String> {
+fn get_column_from_batch(batch: &RecordBatch, column: usize) -> Vec<String> {
     let results = batch.column(column).as_string::<i32>();
 
     results
         .iter()
         .filter_map(|s| Some(s?.to_string()))
         .collect()
+}
+
+// TODO: Implement a `migrate` function to migrate to a new DB version
+
+/// Sync the version stored in the metadata table with the data table version. This should be called
+/// after each DB update, including inserts/upserts, version restores, and schema updates.
+async fn sync_table_version(db: &Connection) -> Result<(), LanceError> {
+    let data_tbl = db.open_table(LANCE_DATA_TABLE_NAME).execute().await?;
+    let meta_tbl = db.open_table(LANCE_META_TABLE_NAME).execute().await?;
+
+    let new_version = data_tbl.version().await?;
+    meta_tbl
+        .update()
+        .column(
+            MetadataTableColumns::DataTableVersion,
+            format!("{new_version} + 1"),
+        )
+        .execute()
+        .await?;
+
+    Ok(())
 }
 
 #[async_trait]
@@ -175,18 +253,18 @@ impl VectorBackend for LanceBackend {
             .map_err(|e| LanceError::ConnectionError(e.to_string()))?;
 
         let tbl = db
-            .open_table(LANCE_TABLE_NAME)
+            .open_table(LANCE_DATA_TABLE_NAME)
             .execute()
             .await
             .map_err(|_| {
                 LanceError::InvalidStateError(format!(
-                    "The table {LANCE_TABLE_NAME} does not exist"
+                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
                 ))
             })?;
 
         let table_version = tbl.version().await.map_err(|e| {
             LanceError::InvalidStateError(format!(
-                "Failed to get version of table {LANCE_TABLE_NAME}: {e}"
+                "Failed to get version of table {LANCE_DATA_TABLE_NAME}: {e}"
             ))
         })?;
 
@@ -199,15 +277,51 @@ impl VectorBackend for LanceBackend {
 
         let num_rows = tbl.count_rows(None).await.map_err(|e| {
             LanceError::InvalidStateError(format!(
-                "Failed to count rows in table {LANCE_TABLE_NAME}: {e}"
+                "Failed to count rows in table {LANCE_DATA_TABLE_NAME}: {e}"
             ))
         })?;
 
-        Ok(LanceMetadata {
-            num_tables,
-            num_rows,
-            embedding_table_version: table_version,
-        })
+        let meta_tbl = db
+            .open_table(LANCE_META_TABLE_NAME)
+            .execute()
+            .await
+            .map_err(|_| {
+                LanceError::InvalidStateError(format!(
+                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
+                ))
+            })?;
+        let mut stream = meta_tbl.query().execute().await?;
+        let Some(batch) = stream.try_next().await? else {
+            return Err(LanceError::InvalidStateError(format!(
+                "The query to {LANCE_META_TABLE_NAME} was successful, but it returned no results."
+            )));
+        };
+
+        let embedding_provider = get_column_from_batch(
+            &batch,
+            MetadataTableColumns::EmbeddingProvider.column_number(),
+        );
+        let embedding_model =
+            get_column_from_batch(&batch, MetadataTableColumns::EmbeddingModel.column_number());
+
+        if let Some(provider_string) = embedding_provider.into_iter().next()
+            && let Ok(provider) = ProviderId::from_str(&provider_string)
+            && let Some(model) = embedding_model.into_iter().next()
+        {
+            Ok(LanceMetadata {
+                num_tables,
+                num_rows,
+                embedding_table_version: table_version,
+                embedding_provider: provider,
+                embedding_model: model,
+            })
+        } else {
+            // TODO: This isn't a useful error message for *users*, it tells them nothing about what
+            // to do; although, there isn't much they can...
+            return Err(LanceError::InvalidStateError(format!(
+                "We got a batch from {LANCE_META_TABLE_NAME}, but the metadata columns were empty."
+            )));
+        }
     }
 
     /// Checks if an existing LanceDB exists and has a valid table
@@ -233,7 +347,7 @@ impl VectorBackend for LanceBackend {
         embedding_col: &str,
     ) -> Result<(), Self::Error> {
         let db = self.connect().await?;
-        let tbl = db.open_table(LANCE_TABLE_NAME).execute().await?;
+        let tbl = db.open_table(LANCE_DATA_TABLE_NAME).execute().await?;
 
         let indices = tbl.list_indices().await?;
         let has_vector_index = indices
@@ -256,6 +370,8 @@ impl VectorBackend for LanceBackend {
             .execute()
             .await?;
         }
+
+        sync_table_version(&db).await?;
 
         // If both indices already existed before this run, they could be optimized here
         // but optimization is optional and can be done separately.
@@ -296,12 +412,12 @@ impl VectorBackend for LanceBackend {
 
         let db = self.connect().await?;
         let table = db
-            .open_table(LANCE_TABLE_NAME)
+            .open_table(LANCE_DATA_TABLE_NAME)
             .execute()
             .await
             .map_err(|_| {
                 LanceError::InvalidStateError(format!(
-                    "The table {LANCE_TABLE_NAME} does not exist"
+                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
                 ))
             })?;
 
@@ -314,6 +430,8 @@ impl VectorBackend for LanceBackend {
 
             table.delete(&delete_pred).await?;
         }
+
+        sync_table_version(&db).await?;
 
         Ok(())
     }
@@ -340,12 +458,12 @@ impl VectorBackend for LanceBackend {
     async fn dedup_rows(&self, by: &str, key: &str) -> Result<usize, Self::Error> {
         let db = self.connect().await?;
         let table = db
-            .open_table(LANCE_TABLE_NAME)
+            .open_table(LANCE_DATA_TABLE_NAME)
             .execute()
             .await
             .map_err(|_| {
                 LanceError::InvalidStateError(format!(
-                    "The table {LANCE_TABLE_NAME} does not exist"
+                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
                 ))
             })?;
 
@@ -385,6 +503,8 @@ impl VectorBackend for LanceBackend {
             self.delete_rows(key, &duplicate_keys).await?;
         }
 
+        sync_table_version(&db).await?;
+
         Ok(deleted_count)
     }
 
@@ -411,12 +531,12 @@ impl VectorBackend for LanceBackend {
         let db = self.connect().await?;
 
         let tbl = db
-            .open_table(LANCE_TABLE_NAME)
+            .open_table(LANCE_DATA_TABLE_NAME)
             .execute()
             .await
             .map_err(|_| {
                 LanceError::InvalidStateError(format!(
-                    "The table {LANCE_TABLE_NAME} does not exist"
+                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
                 ))
             })?;
 
@@ -463,12 +583,12 @@ impl VectorBackend for LanceBackend {
         let db = self.connect().await?;
 
         let tbl = db
-            .open_table(LANCE_TABLE_NAME)
+            .open_table(LANCE_DATA_TABLE_NAME)
             .execute()
             .await
             .map_err(|_| {
                 LanceError::InvalidStateError(format!(
-                    "The table {LANCE_TABLE_NAME} does not exist"
+                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
                 ))
             })?;
         log::debug!("Opening the DB and table took {:.1?}", start_time.elapsed());
@@ -541,12 +661,12 @@ impl VectorBackend for LanceBackend {
 
         let db = self.connect().await?;
         let tbl = db
-            .open_table(LANCE_TABLE_NAME)
+            .open_table(LANCE_DATA_TABLE_NAME)
             .execute()
             .await
             .map_err(|_| {
                 LanceError::InvalidStateError(format!(
-                    "The table {LANCE_TABLE_NAME} does not exist"
+                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
                 ))
             })?;
 
@@ -597,12 +717,12 @@ impl VectorBackend for LanceBackend {
 
         let db = self.connect().await?;
         let tbl = db
-            .open_table(LANCE_TABLE_NAME)
+            .open_table(LANCE_DATA_TABLE_NAME)
             .execute()
             .await
             .map_err(|_| {
                 LanceError::InvalidStateError(format!(
-                    "The table {LANCE_TABLE_NAME} does not exist"
+                    "The table {LANCE_DATA_TABLE_NAME} does not exist"
                 ))
             })?;
 
@@ -653,7 +773,7 @@ impl VectorBackend for LanceBackend {
         {
             // Add rows if they don't already exist
             let tbl = db
-                .open_table(LANCE_TABLE_NAME)
+                .open_table(LANCE_DATA_TABLE_NAME)
                 .execute()
                 .await
                 .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
@@ -677,14 +797,58 @@ impl VectorBackend for LanceBackend {
                 Some("embeddings"),
             );
 
+            // LanceDB allows useful operations such as schema updates, and each of those is
+            // associated with a new table version. In the future, we might switch to a different
+            // schema, such as with different types (which LanceDB also supports); in this case,
+            // recording a minimum supported lib version is necessary.
+            let lib_version = env!("CARGO_PKG_VERSION");
+            let metadata_record = record_batch!(
+                (
+                    MetadataTableColumns::LibVersion.as_str(),
+                    Utf8,
+                    [lib_version]
+                ),
+                // This lets us allow switching models, which is on the roadmap anyway
+                (
+                    MetadataTableColumns::DataTableVersion.as_str(),
+                    Int32,
+                    [1] // LanceDB tables start at version 1
+                ),
+                (
+                    MetadataTableColumns::EmbeddingProvider.as_str(),
+                    Utf8,
+                    [self.config.provider_id().as_str()]
+                ),
+                (
+                    MetadataTableColumns::EmbeddingModel.as_str(),
+                    Utf8,
+                    [self.config.model_name()]
+                )
+            )?;
+
+            // Create the metadata table first. This order guarantees that in the worst case, we
+            // end up with a DB that knows which provider is being used and has no data; the
+            // alternative would be a DB that has data but does not "know" what model/provider were
+            // used to generate those embeddings.
+            //
+            // If the metadata is stored and creating the data table fails,
+            // [`CreateTableMode::Overwrite`] overwrites it on the next attempt anyway.
+            db.create_table(LANCE_META_TABLE_NAME, metadata_record)
+                .mode(CreateTableMode::Overwrite)
+                .execute()
+                .await
+                .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
+
             // Create a new table and add rows
-            db.create_table(LANCE_TABLE_NAME, items)
+            db.create_table(LANCE_DATA_TABLE_NAME, items)
                 .mode(CreateTableMode::Overwrite)
                 .add_embedding(embedding_params)?
                 .execute()
                 .await
                 .map_err(|e| LanceError::TableUpdateError(e.to_string()))?;
         }
+
+        sync_table_version(&db).await?;
 
         Ok(())
     }
@@ -788,9 +952,9 @@ mod tests {
 
         let tbl_names = conn.table_names().execute().await;
         test_ok!(tbl_names);
-        test_eq!(tbl_names.unwrap(), vec![LANCE_TABLE_NAME]);
+        test_eq!(tbl_names.unwrap(), vec![LANCE_DATA_TABLE_NAME]);
 
-        let tbl = conn.open_table(LANCE_TABLE_NAME).execute().await;
+        let tbl = conn.open_table(LANCE_DATA_TABLE_NAME).execute().await;
         test_ok!(tbl);
 
         let tbl = tbl.unwrap();

--- a/zqa-rag/src/vector/backends/lance.rs
+++ b/zqa-rag/src/vector/backends/lance.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use arrow_array::cast::AsArray;
-use arrow_array::types::Float32Type;
+use arrow_array::types::{Float32Type, Int64Type};
 use arrow_array::{RecordBatch, RecordBatchIterator, StringArray, record_batch};
 use arrow_schema::{ArrowError, Schema};
 use async_trait::async_trait;
@@ -120,8 +120,14 @@ pub struct LanceBackend {
 pub struct LanceMetadata {
     /// Number of tables in the database.
     num_tables: usize,
-    /// The embedding table version. Each update to a table creates a new version.
+    /// The live data table version, read from the data table itself. Each update to a table
+    /// creates a new version, so this is the source of truth for the table's current state.
     embedding_table_version: u64,
+    /// The data table version recorded in the metadata table, i.e. the version the metadata was
+    /// last synced to. Under normal operation this equals [`Self::embedding_table_version`];
+    /// a difference signals that a write bypassed the metadata sync (or the DB was modified out
+    /// of band). See [`LanceBackend::sync_table_version`].
+    stored_data_table_version: u64,
     /// Number of rows in the table
     num_rows: usize,
     /// Embedding provider used
@@ -132,22 +138,23 @@ pub struct LanceMetadata {
 
 impl fmt::Display for LanceMetadata {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
+        writeln!(f, "LanceDB metadata:")?;
+        writeln!(f, "\tNumber of tables: {}", self.num_tables)?;
+        writeln!(f, "\tNumber of rows: {}", self.num_rows)?;
+        writeln!(
             f,
-            concat!(
-                "LanceDB metadata:\n",
-                "\tNumber of tables: {}\n",
-                "\tNumber of rows: {}\n",
-                "\tEmbedding table version: {}\n",
-                "\tModel provider: {}\n",
-                "\tModel: {}\n",
-            ),
-            self.num_tables,
-            self.num_rows,
-            self.embedding_table_version,
-            self.embedding_provider.as_str(),
-            self.embedding_model
-        )
+            "\tEmbedding table version: {}",
+            self.embedding_table_version
+        )?;
+        if self.stored_data_table_version != self.embedding_table_version {
+            writeln!(
+                f,
+                "\t⚠ metadata last synced at v{} (data table is at v{})",
+                self.stored_data_table_version, self.embedding_table_version
+            )?;
+        }
+        writeln!(f, "\tModel provider: {}", self.embedding_provider.as_str())?;
+        writeln!(f, "\tModel: {}", self.embedding_model)
     }
 }
 
@@ -276,6 +283,60 @@ fn get_column_from_batch(batch: &RecordBatch, column: &str) -> Vec<String> {
         .collect()
 }
 
+/// Reads the data table version recorded in the metadata table from a metadata `RecordBatch`.
+///
+/// This is the version the metadata was last synced to (see [`LanceBackend::sync_table_version`]),
+/// not the live data table version.
+///
+/// # Errors
+///
+/// Returns [`LanceError::InvalidStateError`] if the batch is empty, the
+/// [`MetadataTableColumns::DataTableVersion`] column is missing or not `Int64`, or the stored value
+/// is negative.
+fn stored_version_from_batch(batch: &RecordBatch) -> Result<u64, LanceError> {
+    let column = MetadataTableColumns::DataTableVersion.as_str();
+    let values = batch
+        .column_by_name(column)
+        .and_then(|array| array.as_primitive_opt::<Int64Type>())
+        .ok_or_else(|| {
+            LanceError::InvalidStateError(format!(
+                "The metadata table is missing a valid Int64 `{column}` column"
+            ))
+        })?;
+
+    if values.is_empty() {
+        return Err(LanceError::InvalidStateError(format!(
+            "The metadata table `{column}` column has no rows"
+        )));
+    }
+
+    u64::try_from(values.value(0)).map_err(|_| {
+        LanceError::InvalidStateError(format!(
+            "The stored data table version ({}) is negative",
+            values.value(0)
+        ))
+    })
+}
+
+/// Reads the data table version recorded in the metadata table (the version the metadata was
+/// last synced to). Compare against the live data table version (`Table::version`) to detect drift.
+///
+/// # Errors
+///
+/// Returns a [`LanceError`] if the metadata table cannot be opened or queried, or if its
+/// `data_table_version` column is missing, empty, or holds an unexpected value.
+pub(crate) async fn read_stored_data_table_version(db: &Connection) -> Result<u64, LanceError> {
+    let meta_tbl = db.open_table(LANCE_META_TABLE_NAME).execute().await?;
+    let mut stream = meta_tbl.query().execute().await?;
+    let Some(batch) = stream.try_next().await? else {
+        return Err(LanceError::InvalidStateError(format!(
+            "The query to {LANCE_META_TABLE_NAME} was successful, but it returned no results."
+        )));
+    };
+
+    stored_version_from_batch(&batch)
+}
+
 #[async_trait]
 impl VectorBackend for LanceBackend {
     type Record = RecordBatch;
@@ -344,6 +405,7 @@ impl VectorBackend for LanceBackend {
             )));
         };
 
+        let stored_data_table_version = stored_version_from_batch(&batch)?;
         let embedding_provider =
             get_column_from_batch(&batch, MetadataTableColumns::EmbeddingProvider.as_str());
         let embedding_model =
@@ -357,6 +419,7 @@ impl VectorBackend for LanceBackend {
                 num_tables,
                 num_rows,
                 embedding_table_version: table_version,
+                stored_data_table_version,
                 embedding_provider: provider,
                 embedding_model: model,
             })
@@ -1051,6 +1114,61 @@ mod tests {
         .collect();
 
         test_eq!(columns, expected);
+    }
+
+    /// A freshly-created DB is in sync (stored == live, no warning); mutating the data table out
+    /// of band (bypassing `sync_table_version`) advances the live version past the stored one, and
+    /// that drift is both detectable on [`LanceMetadata`] and surfaced in its `Display`.
+    #[tokio::test]
+    async fn test_metadata_version_drift_detection() {
+        dotenv().ok();
+
+        let (_db_dir, uri) = temp_db();
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", arrow_schema::DataType::Utf8, false),
+            arrow_schema::Field::new("text", arrow_schema::DataType::Utf8, false),
+        ]));
+        let rb = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(StringArray::from(vec!["one", "two", "three"])),
+            ],
+        )
+        .unwrap();
+        let backend = LanceBackend::new(get_test_openai_embedding_config(), schema, "text".into())
+            .with_uri(uri.as_str());
+        backend.insert_items(vec![rb], None).await.unwrap();
+
+        // Freshly created: metadata is in sync with the live data table version, no warning shown.
+        let meta = backend.get_metadata().await.unwrap();
+        test_eq!(meta.stored_data_table_version, meta.embedding_table_version);
+        assert!(
+            !format!("{meta}").contains("metadata last synced at"),
+            "in-sync metadata should not render a drift warning"
+        );
+
+        // Mutate the data table out of band — `tbl.delete` bumps the data table version, but
+        // bypasses `sync_table_version`, so the stored version lags behind.
+        let db = backend.connect().await.unwrap();
+        let tbl = db
+            .open_table(LANCE_DATA_TABLE_NAME)
+            .execute()
+            .await
+            .unwrap();
+        tbl.delete("id = 'a'").await.unwrap();
+
+        let meta = backend.get_metadata().await.unwrap();
+        assert!(
+            meta.embedding_table_version > meta.stored_data_table_version,
+            "expected live version {} to exceed stored {}",
+            meta.embedding_table_version,
+            meta.stored_data_table_version
+        );
+        assert!(
+            format!("{meta}").contains("metadata last synced at"),
+            "drifted metadata should render a drift warning"
+        );
     }
 
     #[tokio::test]

--- a/zqa-rag/src/vector/backup.rs
+++ b/zqa-rag/src/vector/backup.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 
 use thiserror::Error;
 
-use crate::vector::backends::lance::{LANCE_TABLE_NAME as TABLE_NAME, get_db_uri};
+use crate::vector::backends::lance::{LANCE_DATA_TABLE_NAME as TABLE_NAME, get_db_uri};
 
 /// Errors that can occur during backup operations
 #[derive(Debug, Error)]

--- a/zqa-rag/src/vector/checkhealth.rs
+++ b/zqa-rag/src/vector/checkhealth.rs
@@ -12,7 +12,9 @@ use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::{Table, connect};
 
 use super::backends::lance::LanceError;
-use super::backends::lance::{LANCE_DATA_TABLE_NAME as TABLE_NAME, get_db_uri};
+use super::backends::lance::{
+    LANCE_DATA_TABLE_NAME as TABLE_NAME, get_db_uri, read_stored_data_table_version,
+};
 use crate::capabilities::EmbeddingProvider;
 use crate::embedding::common::get_embedding_dims_by_provider;
 use crate::providers::ProviderId;
@@ -48,6 +50,11 @@ pub struct HealthCheckResult {
     /// `Some(Ok(index_info))` if we successfully got the index information, and `Some(Err(...))`
     /// when there was an error connecting to the DB or opening the table.
     pub index_info: Option<Result<Vec<(String, String)>, LanceError>>,
+    /// Metadata version drift, as `(stored, live)`: the data table version recorded in the
+    /// metadata table versus the live data table version. `None` when the check hasn't run,
+    /// `Some(Ok((stored, live)))` with the two versions (equal means in sync), and `Some(Err(...))`
+    /// when the versions could not be read.
+    pub version_drift: Option<Result<(u64, u64), LanceError>>,
 }
 
 /// Format file size in a human-readable format
@@ -187,6 +194,31 @@ impl fmt::Display for HealthCheckResult {
                 writeln!(f, "{YELLOW}⚠ Index information check was skipped{RESET}")?;
             }
         }
+        writeln!(f)?;
+
+        // Check 7: Metadata version sync
+        match &self.version_drift {
+            Some(Ok((stored, live))) => {
+                if stored == live {
+                    writeln!(f, "{GREEN}✓ Metadata version is in sync (v{live}){RESET}")?;
+                } else {
+                    writeln!(
+                        f,
+                        "{YELLOW}⚠ Metadata version drift: metadata last synced at v{stored}, but the data table is at v{live}{RESET}"
+                    )?;
+                    writeln!(
+                        f,
+                        "{YELLOW}  → A write may have bypassed metadata sync, or the database was modified out of band{RESET}"
+                    )?;
+                }
+            }
+            Some(Err(e)) => {
+                writeln!(f, "{RED}✗ Failed to check metadata version: {e}{RESET}")?;
+            }
+            None => {
+                writeln!(f, "{YELLOW}⚠ Metadata version check was skipped{RESET}")?;
+            }
+        }
 
         Ok(())
     }
@@ -312,6 +344,7 @@ pub async fn lancedb_health_check(
         num_rows: None,
         zero_embedding_items: None,
         index_info: None,
+        version_drift: None,
     };
 
     // Check 1: Directory existence and size
@@ -376,6 +409,15 @@ pub async fn lancedb_health_check(
             Err(e) => Some(Err(LanceError::QueryError(e.to_string()))),
         }
     }
+
+    // Check 7: Metadata version drift (stored vs live data table version)
+    result.version_drift = Some(match read_stored_data_table_version(&db).await {
+        Ok(stored) => match tbl.version().await {
+            Ok(live) => Ok((stored, live)),
+            Err(e) => Err(LanceError::QueryError(e.to_string())),
+        },
+        Err(e) => Err(e),
+    });
 
     Ok(result)
 }

--- a/zqa-rag/src/vector/checkhealth.rs
+++ b/zqa-rag/src/vector/checkhealth.rs
@@ -12,7 +12,7 @@ use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::{Table, connect};
 
 use super::backends::lance::LanceError;
-use super::backends::lance::{LANCE_TABLE_NAME as TABLE_NAME, get_db_uri};
+use super::backends::lance::{LANCE_DATA_TABLE_NAME as TABLE_NAME, get_db_uri};
 use crate::capabilities::EmbeddingProvider;
 use crate::embedding::common::get_embedding_dims_by_provider;
 use crate::providers::ProviderId;

--- a/zqa/src/cli/handlers/library.rs
+++ b/zqa/src/cli/handlers/library.rs
@@ -522,7 +522,7 @@ mod tests {
                 .await;
         let output = String::from_utf8(ctx.out.into_inner()).unwrap();
         test_ok!(stats);
-        test_contains!(output, "LanceDB Statistics:");
+        test_contains!(output, "LanceDB metadata:");
         test_contains!(output, "Number of rows: 8");
 
         if fs::metadata(BATCH_ITER_FILE).is_ok() {

--- a/zqa/src/utils/arrow.rs
+++ b/zqa/src/utils/arrow.rs
@@ -11,7 +11,7 @@ use zqa_rag::{
         EmbeddingProviderConfig, get_embedding_dims_by_provider, get_embedding_provider_with_config,
     },
     llm::errors::LLMError,
-    vector::backends::lance::{LANCE_TABLE_NAME, LanceError, get_db_uri},
+    vector::backends::lance::{LANCE_DATA_TABLE_NAME, LanceError, get_db_uri},
 };
 
 use super::library::{LibraryParsingError, parse_library};
@@ -98,7 +98,7 @@ pub(crate) async fn lancedb_exists() -> bool {
     }
 
     if let Ok(db) = lancedb::connect(&uri).execute().await {
-        db.open_table(LANCE_TABLE_NAME).execute().await.is_ok()
+        db.open_table(LANCE_DATA_TABLE_NAME).execute().await.is_ok()
     } else {
         false
     }


### PR DESCRIPTION
- Adds a metadata table that stores the provider/model being used and table version.
- Implements version drift detection
- Updates testing in the Lance backend to allow running in parallel
- Not implemented: warning on difference in model/provider: that's left to a future PR; it might belong in `zqa` anyway, though some design is necessary (e.g., maybe update ops check and return a `Result`, but allow a `force` option).

Closes: #235 