### PR TITLE
feat(pdftools): add support for non-array range specifications in CID-keyed fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +663,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -684,6 +724,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1764,6 +1814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2197,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2550,6 +2610,16 @@ dependencies = [
  "unicode-width",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -3424,21 +3494,32 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
+ "aes",
+ "bitflags",
+ "cbc",
  "chrono",
+ "ecb",
  "encoding_rs",
  "flate2",
+ "getrandom 0.4.2",
  "indexmap 2.14.0",
  "itoa",
+ "jiff",
  "log",
  "md-5",
- "nom 7.1.3",
+ "nom 8.0.0",
+ "rand 0.10.1",
  "rangemap",
  "rayon",
+ "sha2",
+ "stringprep",
+ "thiserror",
  "time",
+ "ttf-parser",
  "weezl",
 ]
 
@@ -4211,6 +4292,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4247,6 +4339,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -5134,6 +5232,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5743,6 +5852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5764,10 +5879,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"

--- a/zqa-pdftools/Cargo.toml
+++ b/zqa-pdftools/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 [dependencies]
 itertools = "0.14.0"
 log = "0.4.27"
-lopdf = "0.34.0"
+lopdf = "0.42.0"
 ordered-float = "5.1.0"
 thiserror = "2.0"
 

--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -3,9 +3,13 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use lopdf::{Document, Object};
 use ordered_float::OrderedFloat;
 
-use crate::math::{from_cmex, from_cmmi, from_cmsy, from_msbm};
+use crate::{
+    math::{from_cmex, from_cmmi, from_cmsy, from_msbm},
+    parse::{PageID, PdfError},
+};
 
 /// A struct to keep track of font size changes. This includes all the metadata you might need
 /// about font changes. The primary purpose of this is to track sections, subsections, etc., but
@@ -128,4 +132,354 @@ pub(crate) enum FontEncoding {
     /// two-byte (or multi-byte, but we don't yet handle this) CIDs, custom glyph ID maps, and
     /// `ToUnicode` CMaps for real text extraction.
     CIDKeyed(CMap),
+}
+
+/// CMaps can take two main forms: individual, where `beginbfchar` and `endbfchar` wrap a set of
+/// lines, each with two tokens; and ranged, where `beginbfrange` and `endbfrange` wrap a set of
+/// triples. The first two tokens in the triples mark begin and end of a range, and the third token
+/// can be in hex form or an array (currently, not yet supported).
+#[derive(Debug, PartialEq)]
+enum CMapKind {
+    Individual,
+    Ranged,
+    Unknown,
+}
+
+/// Given a PDF `Document` reference, a page ID, and a font key (e.g., "F19"), return the font
+/// object.
+///
+/// # Arguments
+///
+/// * `doc` - The `lopdf::Document` object.
+/// * `page_id` - The `lopdf` page ID. Different pages can have different font dictionaries,
+///   otherwise operations such as joining PDFs would be more complicated than they already are.
+/// * `font_key` - The font key as used in the PDF content stream.
+///
+/// # Returns
+///
+/// A `HashMap` with string keys mapping to `lopdf::Object` references.
+///
+/// # Errors
+///
+/// * `PdfError::PageFontError` if getting page fonts failed.
+/// * `PdfError::FontNotFound` if the font key does not exist.
+///
+/// # Panics
+///
+/// * If any of the keys in the font dictionary are not valid UTF-8.
+pub(crate) fn get_font<'a>(
+    doc: &'a Document,
+    page_id: PageID,
+    font_key: &str,
+) -> Result<HashMap<&'a str, &'a Object>, PdfError> {
+    // Get the font dictionary for the page
+    let fonts = doc
+        .get_page_fonts(page_id)
+        .map_err(|_| PdfError::PageFontError)?;
+
+    let font_obj = fonts
+        .get(font_key.as_bytes())
+        .ok_or(PdfError::FontNotFound(font_key.into()))?;
+    let font_hash = font_obj.as_hashmap();
+
+    font_hash
+        .iter()
+        .map(|(k, v)| {
+            let key_str = std::str::from_utf8(k)?;
+            Ok((key_str, v))
+        })
+        .collect::<Result<_, _>>()
+}
+
+/// Parse a CMap string. A font key is taken as reference to provide more context in errors.
+///
+/// Currently, this CMap parser supports scenarios with one block of mappings per font, and only
+/// supports `beginbfchar`..`endbfchar` and `beginbfrange`..`endbfrange`s, i.e., it does not support
+/// more complex use cases such as those involving `begincidrange`..`endcidrange`. Note that per
+/// ISO 32000-1:2008, §9.7.5.4(e), `beginrearrangedfont`..`endrearrangedfont` should not be used in
+/// embedded CMaps; moreover, `usefont`s should only specify a font number of 0.
+pub(crate) fn parse_cmap(
+    cmap: String,
+    font_key: &str,
+) -> Result<HashMap<String, String>, PdfError> {
+    // TODO: (ZOT-202) Technically, the number of entries in each block is limited to 100,
+    // so a CID mapping can have multiple blocks. We should parse all such blocks, not just
+    // the first.
+
+    let cmap_kind = if cmap.contains("beginbfchar") {
+        CMapKind::Individual
+    } else if cmap.contains("beginbfranged") {
+        CMapKind::Ranged
+    } else {
+        CMapKind::Unknown
+    };
+
+    match cmap_kind {
+        CMapKind::Unknown => {
+            return Err(PdfError::EncodingError(format!(
+                "CMap type for {font_key} could not be determined."
+            )));
+        }
+        CMapKind::Individual => {
+            let csrange_begin = cmap.find("beginbfchar").unwrap() + "beginbfchar".len();
+            let csrange_end = cmap
+                .find("endbfchar")
+                .ok_or(PdfError::EncodingError(format!(
+                    "Deflated ToUnicode CMap for font {font_key} has no `endbfchar`."
+                )))?;
+
+            let csrange = cmap[csrange_begin..csrange_end].trim();
+            let lines = csrange.split('\n');
+
+            let mut mappings = HashMap::new();
+
+            // Within the CMap, each line has the following form:
+            //   <001B> <0041>
+            // In this case, the 2-byte CID 001B maps to U+0041.
+            for line in lines {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() != 2 {
+                    log::warn!(
+                        "In CMap for {font_key}, unexpected line with {} tokens.",
+                        parts.len()
+                    );
+                    continue;
+                }
+
+                let cid = parts[0].trim_matches(|c| c == '<' || c == '>');
+
+                // In some cases, `parts[1]` can have multiple Unicode code points. This is
+                // sometimes done to handle ligatures, among others. For example, the ligature
+                // `ff` is represented as two U+066 code points.
+                let code_units: Vec<u16> = parts[1]
+                    .trim_matches(|c| c == '<' || c == '>')
+                    .as_bytes()
+                    .chunks_exact(4)
+                    .map(|chunk| u16::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16))
+                    .collect::<Result<_, _>>()
+                    .map_err(|_| PdfError::InvalidUtf8)?;
+
+                let unicode: String = std::char::decode_utf16(code_units)
+                    .map(|r| r.map_err(|e| PdfError::EncodingError(format!("Invalid UTF-16: {e}"))))
+                    .collect::<Result<_, _>>()?;
+
+                mappings.insert(cid.to_string().to_lowercase(), unicode);
+            }
+
+            Ok(mappings)
+        }
+        CMapKind::Ranged => {
+            let csrange_begin = cmap.find("beginbfrange").unwrap() + "beginbfrange".len();
+            let csrange_end = cmap
+                .find("endbfrange")
+                .ok_or(PdfError::EncodingError(format!(
+                    "Deflated ToUnicode CMap for font {font_key} has no `endbfrange`."
+                )))?;
+
+            let csrange = cmap[csrange_begin..csrange_end].trim();
+            let lines = csrange.split('\n');
+
+            let mut mappings = HashMap::new();
+
+            // Within the CMap, each line has the following form:
+            //   <000B> <000C> <0028>
+            // In this case, we have:
+            //   * CID 000B -> U+0028
+            //   * CID 000C -> U+0029
+            for line in lines {
+                if line.contains('[') {
+                    log::error!("CMaps with `bfrange`s that contain arrays are not yet supported.");
+                    return Err(PdfError::EncodingError(
+                        "Unsupported CID map with arrays in range.".into(),
+                    ));
+                }
+
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() != 3 {
+                    log::warn!(
+                        "In CMap for {font_key}, unexpected line with {} tokens.",
+                        parts.len()
+                    );
+                    continue;
+                }
+
+                let start_cid = parts[0].trim_matches(|c| c == '<' || c == '>');
+                let end_cid = parts[1].trim_matches(|c| c == '<' || c == '>');
+
+                let start_cid_u16 = u16::from_str_radix(start_cid, 16).map_err(|_| {
+                    PdfError::EncodingError(format!(
+                        "In CMap for {font_key}, CID {start_cid} was not valid UTF-16"
+                    ))
+                })?;
+                let end_cid_u16 = u16::from_str_radix(end_cid, 16).map_err(|_| {
+                    PdfError::EncodingError(format!(
+                        "In CMap for {font_key}, CID {end_cid} was not valid UTF-16"
+                    ))
+                })?;
+
+                // Again, parts[2] can have multiple UTF-16BE code units. In this case, for each
+                // consecutive code in the source code range, we increment the last byte of the
+                // string, see the PDF standard, ISO 32000-1:2008, §9.10.3 ("ToUnicode CMaps").
+                // This means that we don't treat the hex string as one Big Endian integer, and only
+                // look at the last byte for the purposes of the range.
+                let code_units: Vec<u16> = parts[2]
+                    .trim_matches(|c| c == '<' || c == '>')
+                    .as_bytes()
+                    .chunks_exact(4)
+                    .map(|chunk| u16::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16))
+                    .collect::<Result<_, _>>()
+                    .map_err(|_| PdfError::InvalidUtf8)?;
+
+                for i in start_cid_u16..end_cid_u16 + 1 {
+                    let mut cur_char_units = code_units.clone();
+                    cur_char_units.last_mut().and_then(|&mut ref mut c| {
+                        *c += 1;
+                        Some(())
+                    });
+                    let unicode: String = std::char::decode_utf16(cur_char_units)
+                        .map(|r| {
+                            r.map_err(|e| PdfError::EncodingError(format!("Invalid UTF-16: {e}")))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    mappings.insert(i.to_string().to_lowercase(), unicode);
+                }
+            }
+
+            Ok(mappings)
+        }
+    }
+}
+
+/// Attempt to get the font encoding for a font key on a specific page.
+///
+/// This function uses heuristics to determine whether a font is likely to be "simple" (i.e.,
+/// can be parsed as plain-text), or needs to be translated via a corresponding CMap.
+///
+/// # Returns
+///
+/// If the specified font is a CID-keyed font, returns `FontEncoding::CIDKeyed` with a
+/// reference to the `ToUnicode` CMap. Otherwise, returns `FontEncoding::Simple`.
+///
+/// # Errors
+///
+/// * `PdfError::PageFontError` if getting page fonts failed.
+/// * `PdfError::FontNotFound` if the font key does not exist.
+/// * `PdfError::EncodingError` if the font dictionary:
+///      * Has an /Encoding that could not be read
+///      * Indicates a CID-keyed font but does not have a ToUnicode CMap.
+///      * Has a ToUnicode CMap that could not be read or deflated.
+///      * Has a ToUnicode CMap without a `beginbfchar` or `endbfchar` marker.
+/// * `PdfError::InternalError` if the font dictionary:
+///      * Does not have a /Subtype that could be read.
+///      * Has a /ToUnicode reference that is invalid.
+/// * `PdfError::InvalidUtf8` if the deflated ToUnicode CMap is not valid UTF-8.
+///
+/// # Panics
+///
+/// * If any of the keys in the font dictionary are not valid UTF-8.
+pub(crate) fn compute_font_encoding(
+    doc: &Document,
+    page_id: PageID,
+    font_key: &str,
+) -> Result<FontEncoding, PdfError> {
+    let font_obj = get_font(doc, page_id, font_key)?;
+
+    // Test 1: if the font has:
+    //   /Subtype /Type1
+    //   /Subtype /TrueType
+    // then it is likely a "simple" font.
+    let font_subtype = str::from_utf8(
+        font_obj
+            .get("Subtype")
+            .ok_or(PdfError::MissingSubtype)?
+            .as_name()
+            .map_err(|_| {
+                PdfError::InternalError(format!(
+                    "Expected font {font_key}'s Subtype key to be a `name`"
+                ))
+            })?,
+    )
+    .map_err(|e| {
+        PdfError::InternalError(format!(
+            "Font {font_key}'s Subtype value is not valid UTF-8: {e}"
+        ))
+    })?;
+
+    if ["Type1", "TrueType"].contains(&font_subtype) {
+        return Ok(FontEncoding::Simple);
+    }
+
+    // Test 2: if the font has:
+    //   /Encoding /Identity-H
+    //   /Encoding /Identity-V
+    // then it is likely a CID-keyed font. However, if it has:
+    //   /Encoding /WinAnsiEncoding
+    //   /Encoding /MacRomanEncoding
+    // it is likely a "simple" font.
+    let Some(font_encoding) = font_obj.get("Encoding") else {
+        log::warn!(
+            "Could not determine font type for {font_key}, assuming simple. This may be wrong."
+        );
+        return Ok(FontEncoding::Simple);
+    };
+    let font_encoding = str::from_utf8(font_encoding.as_name().map_err(|_| {
+        PdfError::EncodingError(format!(
+            "Expected font {font_key}'s Encoding key to be a `name`"
+        ))
+    })?)
+    .map_err(|e| {
+        PdfError::EncodingError(format!(
+            "Font {font_key}'s Encoding name is not valid UTF-8: {e}"
+        ))
+    })?;
+
+    if ["WinAnsiEncoding", "MacRomanEncoding"].contains(&font_encoding) {
+        return Ok(FontEncoding::Simple);
+    } else if ["Identity-H", "Identity-V"].contains(&font_encoding) || font_encoding == "Type0" {
+        // Test 3: if the font has:
+        //   /Subtype /Type0
+        // then it is likely a CID-keyed font.
+        let cmap_ref = font_obj
+            .get("ToUnicode")
+            .ok_or(PdfError::EncodingError(format!(
+                "CID-keyed font {font_key} does not have a ToUnicode CMap.",
+            )))?
+            .as_reference()
+            .map_err(|_| {
+                PdfError::EncodingError(format!(
+                    "CID-keyed font {font_key}'s ToUnicode CMap could not be read."
+                ))
+            })?;
+
+        let decompressed = doc
+            .get_object(cmap_ref)
+            .map_err(|_| {
+                PdfError::InternalError(format!(
+                    "Font {font_key}'s ToUnicode CMap points to invalid reference.",
+                ))
+            })?
+            .as_stream()
+            .map_err(|_| {
+                PdfError::EncodingError(format!(
+                    "CID-keyed font {font_key}'s ToUnicode CMap could not be read."
+                ))
+            })?
+            .decompressed_content()
+            .map_err(|_| {
+                PdfError::EncodingError(format!(
+                    "CID-keyed font {font_key}'s ToUnicode CMap could not be deflated."
+                ))
+            })?;
+
+        let cmap = String::from_utf8(decompressed).map_err(|_| PdfError::InvalidUtf8)?;
+        let mappings = parse_cmap(cmap, font_key)?;
+
+        return Ok(FontEncoding::CIDKeyed(mappings));
+    } else {
+        // If we got here, then we don't have a good idea; emit a warning and assume Simple.
+        log::warn!(
+            "No heuristic matched for font {font_key}; assuming simple. This is likely wrong."
+        );
+        return Ok(FontEncoding::Simple);
+    }
 }

--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -198,28 +198,24 @@ pub(crate) fn get_font<'a>(
 /// more complex use cases such as those involving `begincidrange`..`endcidrange`. Note that per
 /// ISO 32000-1:2008, §9.7.5.4(e), `beginrearrangedfont`..`endrearrangedfont` should not be used in
 /// embedded CMaps; moreover, `usefont`s should only specify a font number of 0.
-pub(crate) fn parse_cmap(
-    cmap: String,
-    font_key: &str,
-) -> Result<HashMap<String, String>, PdfError> {
+#[allow(clippy::too_many_lines)]
+pub(crate) fn parse_cmap(cmap: &str, font_key: &str) -> Result<HashMap<String, String>, PdfError> {
     // TODO: (ZOT-202) Technically, the number of entries in each block is limited to 100,
     // so a CID mapping can have multiple blocks. We should parse all such blocks, not just
     // the first.
 
     let cmap_kind = if cmap.contains("beginbfchar") {
         CMapKind::Individual
-    } else if cmap.contains("beginbfranged") {
+    } else if cmap.contains("beginbfrange") {
         CMapKind::Ranged
     } else {
         CMapKind::Unknown
     };
 
     match cmap_kind {
-        CMapKind::Unknown => {
-            return Err(PdfError::EncodingError(format!(
-                "CMap type for {font_key} could not be determined."
-            )));
-        }
+        CMapKind::Unknown => Err(PdfError::EncodingError(format!(
+            "CMap type for {font_key} could not be determined."
+        ))),
         CMapKind::Individual => {
             let csrange_begin = cmap.find("beginbfchar").unwrap() + "beginbfchar".len();
             let csrange_end = cmap
@@ -330,18 +326,18 @@ pub(crate) fn parse_cmap(
                     .collect::<Result<_, _>>()
                     .map_err(|_| PdfError::InvalidUtf8)?;
 
-                for i in start_cid_u16..end_cid_u16 + 1 {
+                for i in start_cid_u16..=end_cid_u16 {
                     let mut cur_char_units = code_units.clone();
-                    cur_char_units.last_mut().and_then(|&mut ref mut c| {
-                        *c += 1;
-                        Some(())
-                    });
+
+                    if let Some(c) = cur_char_units.last_mut() {
+                        *c += i - start_cid_u16;
+                    }
                     let unicode: String = std::char::decode_utf16(cur_char_units)
                         .map(|r| {
                             r.map_err(|e| PdfError::EncodingError(format!("Invalid UTF-16: {e}")))
                         })
                         .collect::<Result<_, _>>()?;
-                    mappings.insert(i.to_string().to_lowercase(), unicode);
+                    mappings.insert(format!("{i:04x}"), unicode);
                 }
             }
 
@@ -434,7 +430,7 @@ pub(crate) fn compute_font_encoding(
     })?;
 
     if ["WinAnsiEncoding", "MacRomanEncoding"].contains(&font_encoding) {
-        return Ok(FontEncoding::Simple);
+        Ok(FontEncoding::Simple)
     } else if ["Identity-H", "Identity-V"].contains(&font_encoding) || font_encoding == "Type0" {
         // Test 3: if the font has:
         //   /Subtype /Type0
@@ -472,14 +468,14 @@ pub(crate) fn compute_font_encoding(
             })?;
 
         let cmap = String::from_utf8(decompressed).map_err(|_| PdfError::InvalidUtf8)?;
-        let mappings = parse_cmap(cmap, font_key)?;
+        let mappings = parse_cmap(&cmap, font_key)?;
 
-        return Ok(FontEncoding::CIDKeyed(mappings));
+        Ok(FontEncoding::CIDKeyed(mappings))
     } else {
         // If we got here, then we don't have a good idea; emit a warning and assume Simple.
         log::warn!(
             "No heuristic matched for font {font_key}; assuming simple. This is likely wrong."
         );
-        return Ok(FontEncoding::Simple);
+        Ok(FontEncoding::Simple)
     }
 }

--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -479,3 +479,67 @@ pub(crate) fn compute_font_encoding(
         Ok(FontEncoding::Simple)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cmap_ranged() {
+        // A range that walks from CID 000B to 000C, mapping the last code unit upward from
+        // U+0028 ('('). So 000B -> '(' and 000C -> ')'.
+        let cmap = "\
+1 beginbfrange
+<000b> <000c> <0028>
+endbfrange";
+
+        let mappings = parse_cmap(cmap, "F1").expect("ranged CMap should parse");
+
+        assert_eq!(mappings.len(), 2);
+        assert_eq!(mappings.get("000b"), Some(&"(".to_string()));
+        assert_eq!(mappings.get("000c"), Some(&")".to_string()));
+    }
+
+    #[test]
+    fn test_parse_cmap_ranged_multi_entry() {
+        // Two ranges in a single block, with the start CID and Unicode code points not aligned.
+        // The first range maps 0041..=0043 onto 'a'..='c'; the second maps a single CID 0050 to 'Z'.
+        let cmap = "\
+2 beginbfrange
+<0041> <0043> <0061>
+<0050> <0050> <005a>
+endbfrange";
+
+        let mappings = parse_cmap(cmap, "F2").expect("ranged CMap should parse");
+
+        assert_eq!(mappings.len(), 4);
+        assert_eq!(mappings.get("0041"), Some(&"a".to_string()));
+        assert_eq!(mappings.get("0042"), Some(&"b".to_string()));
+        assert_eq!(mappings.get("0043"), Some(&"c".to_string()));
+        assert_eq!(mappings.get("0050"), Some(&"Z".to_string()));
+    }
+
+    #[test]
+    fn test_parse_cmap_ranged_rejects_arrays() {
+        // Array destinations in a `bfrange` are not yet supported and must surface an error
+        // rather than silently dropping the line.
+        let cmap = "\
+1 beginbfrange
+<0001> <0003> [<0041> <0042> <0043>]
+endbfrange";
+
+        let err = parse_cmap(cmap, "F3").expect_err("array ranges are unsupported");
+        assert!(matches!(err, PdfError::EncodingError(_)));
+    }
+
+    #[test]
+    fn test_parse_cmap_ranged_missing_end_marker() {
+        // A `beginbfrange` without its matching `endbfrange` is an error.
+        let cmap = "\
+1 beginbfrange
+<000b> <000c> <0028>";
+
+        let err = parse_cmap(cmap, "F4").expect_err("missing endbfrange should error");
+        assert!(matches!(err, PdfError::EncodingError(_)));
+    }
+}

--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -318,7 +318,7 @@ pub(crate) fn parse_cmap(cmap: &str, font_key: &str) -> Result<HashMap<String, S
                 // string, see the PDF standard, ISO 32000-1:2008, §9.10.3 ("ToUnicode CMaps").
                 // This means that we don't treat the hex string as one Big Endian integer, and only
                 // look at the last byte for the purposes of the range.
-                let code_units: Vec<u16> = parts[2]
+                let mut code_units: Vec<u16> = parts[2]
                     .trim_matches(|c| c == '<' || c == '>')
                     .as_bytes()
                     .chunks_exact(4)
@@ -326,13 +326,12 @@ pub(crate) fn parse_cmap(cmap: &str, font_key: &str) -> Result<HashMap<String, S
                     .collect::<Result<_, _>>()
                     .map_err(|_| PdfError::InvalidUtf8)?;
 
+                let original_last = code_units.last().copied();
                 for i in start_cid_u16..=end_cid_u16 {
-                    let mut cur_char_units = code_units.clone();
-
-                    if let Some(c) = cur_char_units.last_mut() {
-                        *c += i - start_cid_u16;
+                    if let (Some(c), Some(orig)) = (code_units.last_mut(), original_last) {
+                        *c = orig + (i - start_cid_u16);
                     }
-                    let unicode: String = std::char::decode_utf16(cur_char_units)
+                    let unicode: String = std::char::decode_utf16(code_units.iter().copied())
                         .map(|r| {
                             r.map_err(|e| PdfError::EncodingError(format!("Invalid UTF-16: {e}")))
                         })
@@ -364,7 +363,8 @@ pub(crate) fn parse_cmap(cmap: &str, font_key: &str) -> Result<HashMap<String, S
 ///      * Has an /Encoding that could not be read
 ///      * Indicates a CID-keyed font but does not have a ToUnicode CMap.
 ///      * Has a ToUnicode CMap that could not be read or deflated.
-///      * Has a ToUnicode CMap without a `beginbfchar` or `endbfchar` marker.
+///      * Has a ToUnicode CMap without a `beginbfchar`, `endbfchar`, `beginbfrange`, or
+///        `endbfrange` marker.
 /// * `PdfError::InternalError` if the font dictionary:
 ///      * Does not have a /Subtype that could be read.
 ///      * Has a /ToUnicode reference that is invalid.

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -3,7 +3,6 @@
 //! later. The parser also handles common math symbols and converts them to their corresponding
 //! LaTeX equivalents.
 
-use std::char::decode_utf16;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::f32;
@@ -13,11 +12,13 @@ use std::{error::Error, str};
 
 use itertools::Itertools;
 use log;
-use lopdf::{Document, Object};
+use lopdf::Document;
 use ordered_float::OrderedFloat;
 
 use crate::edits::{Edit, EditType, apply_edits};
-use crate::fonts::{FONT_TRANSFORMS, FontEncoding, FontSizeMarker, font_transform};
+use crate::fonts::{
+    FONT_TRANSFORMS, FontEncoding, FontSizeMarker, compute_font_encoding, font_transform, get_font,
+};
 use crate::tokenizer::{Token, tokenize};
 
 const ASCII_PLUS: u8 = b'+';
@@ -33,7 +34,7 @@ pub const DEFAULT_TBL_TD_THRESHOLD: usize = 5;
 
 /// A wrapper for all PDF parsing errors
 #[derive(Debug, thiserror::Error)]
-enum PdfError {
+pub(crate) enum PdfError {
     #[error("Failed to get page content")]
     ContentError,
     #[error("Font key \"{0}\" not found in dictionary")]
@@ -173,7 +174,7 @@ struct PdfParser {
 
 /// `lopdf` references individual pages by a tuple of unsigned integers. Usually, the specific
 /// values are irrelevant, and it is more useful to think about the page ID itself as one "thing".
-type PageID = (u32, u16);
+pub(crate) type PageID = (u32, u16);
 
 /// Having collected all the positions where the y position was changed, collect the edits
 /// necessary to add sub/superscript markers. The core idea here is that when we "come back"
@@ -330,170 +331,7 @@ impl PdfParser {
         match self.font_type.entry((page_id, font_key.to_string())) {
             Entry::Occupied(entry) => Ok(entry.into_mut()),
             Entry::Vacant(entry) => {
-                let font_obj = get_font(doc, page_id, font_key)?;
-
-                // Determine the font encoding type
-                let font_encoding_type = {
-                    // Test 1: if the font has:
-                    //   /Subtype /Type1
-                    //   /Subtype /TrueType
-                    // then it is likely a "simple" font.
-                    let font_subtype = str::from_utf8(
-                        font_obj
-                            .get("Subtype")
-                            .ok_or(PdfError::MissingSubtype)?
-                            .as_name()
-                            .map_err(|_| {
-                                PdfError::InternalError(format!(
-                                    "Expected font {font_key}'s Subtype key to be a `name`"
-                                ))
-                            })?,
-                    )
-                    .map_err(|e| {
-                        PdfError::InternalError(format!(
-                            "Font {font_key}'s Subtype value is not valid UTF-8: {e}"
-                        ))
-                    })?;
-
-                    if ["Type1", "TrueType"].contains(&font_subtype) {
-                        FontEncoding::Simple
-                    } else {
-                        // Test 2: if the font has:
-                        //   /Encoding /Identity-H
-                        //   /Encoding /Identity-V
-                        // then it is likely a CID-keyed font. However, if it has:
-                        //   /Encoding /WinAnsiEncoding
-                        //   /Encoding /MacRomanEncoding
-                        // it is likely a "simple" font.
-                        let encoding = font_obj.get("Encoding");
-                        if let Some(font_encoding) = encoding {
-                            let font_encoding =
-                                str::from_utf8(font_encoding.as_name().map_err(|_| {
-                                    PdfError::EncodingError(format!(
-                                        "Expected font {font_key}'s Encoding key to be a `name`"
-                                    ))
-                                })?)
-                                .map_err(|e| {
-                                    PdfError::EncodingError(format!(
-                                        "Font {font_key}'s Encoding name is not valid UTF-8: {e}"
-                                    ))
-                                })?;
-
-                            if ["WinAnsiEncoding", "MacRomanEncoding"].contains(&font_encoding) {
-                                FontEncoding::Simple
-                            } else if ["Identity-H", "Identity-V"].contains(&font_encoding)
-                                || font_encoding == "Type0"
-                            {
-                                // Test 3: if the font has:
-                                //   /Subtype /Type0
-                                // then it is likely a CID-keyed font.
-                                let cmap_ref = font_obj
-                            .get("ToUnicode")
-                            .ok_or(PdfError::EncodingError(format!(
-                                "CID-keyed font {font_key} does not have a ToUnicode CMap.",
-                            )))?
-                            .as_reference()
-                            .map_err(|_| {
-                                PdfError::EncodingError(format!(
-                                    "CID-keyed font {font_key}'s ToUnicode CMap could not be read."
-                                ))
-                            })?;
-
-                                let f = doc.get_object(cmap_ref);
-                                let decompressed = f
-                            .map_err(|_| {
-                                PdfError::InternalError(format!(
-                                    "Font {font_key}'s ToUnicode CMap points to invalid reference.",
-                                ))
-                            })?
-                            .as_stream()
-                            .map_err(|_| {
-                                PdfError::EncodingError(format!(
-                                    "CID-keyed font {font_key}'s ToUnicode CMap could not be read."
-                                ))
-                            })?
-                            .decompressed_content()
-                            .map_err(|_| {
-                                PdfError::EncodingError(format!(
-                                    "CID-keyed font {font_key}'s ToUnicode CMap could not be deflated."
-                                ))
-                            })?;
-
-                                let cmap = String::from_utf8(decompressed)
-                                    .map_err(|_| PdfError::InvalidUtf8)?;
-                                let csrange_begin = cmap.find("beginbfchar").ok_or(
-                            PdfError::EncodingError(format!(
-                                "Deflated ToUnicode CMap for font {font_key} has no `beginbfchar`."
-                            )),
-                        )? + "beginbfchar".len();
-                                let csrange_end = cmap.find("endbfchar").ok_or(PdfError::EncodingError(
-                            format!(
-                                "Deflated ToUnicode CMap for font {font_key} has no `endbfchar`."
-                            ),
-                        ))?;
-
-                                let csrange = cmap[csrange_begin..csrange_end].trim();
-                                let lines = csrange.split('\n');
-
-                                let mut mappings = HashMap::new();
-
-                                // Within the CMap, each line has the following form:
-                                //   <001B> <0041>
-                                // In this case, the 2-byte CID 001B maps to U+0041.
-                                for line in lines {
-                                    let parts: Vec<&str> = line.split_whitespace().collect();
-                                    if parts.len() == 2 {
-                                        let cid = parts[0].trim_matches(|c| c == '<' || c == '>');
-
-                                        // In some cases, `parts[1]` can have multiple Unicode code points. This is
-                                        // sometimes done to handle ligatures, among others. For example, the ligature
-                                        // `ff` is represented as two U+066 code points.
-                                        let code_units: Vec<u16> = parts[1]
-                                            .trim_matches(|c| c == '<' || c == '>')
-                                            .as_bytes()
-                                            .chunks_exact(4)
-                                            .map(|chunk| {
-                                                u16::from_str_radix(
-                                                    std::str::from_utf8(chunk).unwrap(),
-                                                    16,
-                                                )
-                                            })
-                                            .collect::<Result<_, _>>()
-                                            .map_err(|_| PdfError::InvalidUtf8)?;
-
-                                        let unicode: String = decode_utf16(code_units)
-                                            .map(|r| {
-                                                r.map_err(|e| {
-                                                    PdfError::EncodingError(format!(
-                                                        "Invalid UTF-16: {e}"
-                                                    ))
-                                                })
-                                            })
-                                            .collect::<Result<_, _>>()?;
-
-                                        mappings.insert(cid.to_string().to_lowercase(), unicode);
-                                    }
-                                }
-
-                                FontEncoding::CIDKeyed(mappings)
-                            } else {
-                                // If we got here, then we don't have a good idea; emit a warning and assume Simple.
-                                log::warn!(
-                                    "No heuristic matched for font {font_key}; assuming simple. This is likely wrong."
-                                );
-                                FontEncoding::Simple
-                            }
-                        } else {
-                            log::warn!(
-                                "Could not determine font type for {font_key}, assuming simple. This may be wrong."
-                            );
-                            FontEncoding::Simple
-                        }
-                    }
-                };
-
-                // Insert into cache via vacant entry and return reference
-                Ok(entry.insert(font_encoding_type))
+                Ok(entry.insert(compute_font_encoding(doc, page_id, font_key)?))
             }
         }
     }
@@ -1022,52 +860,6 @@ impl PdfParser {
             body_font_size,
         })
     }
-}
-
-/// Given a PDF `Document` reference, a page ID, and a font key (e.g., "F19"), return the font
-/// object.
-///
-/// # Arguments
-///
-/// * `doc` - The `lopdf::Document` object.
-/// * `page_id` - The `lopdf` page ID. Different pages can have different font dictionaries,
-///   otherwise operations such as joining PDFs would be more complicated than they already are.
-/// * `font_key` - The font key as used in the PDF content stream.
-///
-/// # Returns
-///
-/// A `HashMap` with string keys mapping to `lopdf::Object` references.
-///
-/// # Errors
-///
-/// * `PdfError::PageFontError` if getting page fonts failed.
-/// * `PdfError::FontNotFound` if the font key does not exist.
-///
-/// # Panics
-///
-/// * If any of the keys in the font dictionary are not valid UTF-8.
-fn get_font<'a>(
-    doc: &'a Document,
-    page_id: PageID,
-    font_key: &str,
-) -> Result<HashMap<&'a str, &'a Object>, PdfError> {
-    // Get the font dictionary for the page
-    let fonts = doc
-        .get_page_fonts(page_id)
-        .map_err(|_| PdfError::PageFontError)?;
-
-    let font_obj = fonts
-        .get(font_key.as_bytes())
-        .ok_or(PdfError::FontNotFound(font_key.into()))?;
-    let font_hash = font_obj.as_hashmap();
-
-    font_hash
-        .iter()
-        .map(|(k, v)| {
-            let key_str = std::str::from_utf8(k)?;
-            Ok((key_str, v))
-        })
-        .collect::<Result<_, _>>()
 }
 
 /// Given a PDF `Document` reference, a page ID, and a font key (e.g., "F19"), return the font


### PR DESCRIPTION
Contributes to: ZOT-191