### PR TITLE
refactor!: avoid bypassing `Context` I/O, remove progress bars from `zqa-rag`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6766,7 +6766,6 @@ dependencies = [
  "dotenv",
  "futures",
  "http",
- "indicatif",
  "lancedb",
  "log",
  "rand 0.9.4",

--- a/zqa-rag/Cargo.toml
+++ b/zqa-rag/Cargo.toml
@@ -21,7 +21,6 @@ bytes = "1.6.0"
 dotenv = "^0.15.0"
 futures = "^0.3.31"
 http = "1.3.1"
-indicatif = "^0.18.4"
 lancedb = { version = "^0.27.0", default-features = false  }
 log = "0.4.27"
 rand = "0.9.2"

--- a/zqa-rag/src/embedding/common.rs
+++ b/zqa-rag/src/embedding/common.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, Instant};
 
 use arrow_schema::{DataType, Field};
 use futures::{StreamExt, stream};
-use indicatif::ProgressBar;
 use lancedb::embeddings::EmbeddingFunction;
 use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize};
@@ -255,7 +254,6 @@ where
     let texts: Vec<Option<String>> = source_array.iter().map(|s| s.map(str::to_owned)).collect();
 
     log::info!("Processing {} input texts.", texts.len());
-    let bar = ProgressBar::new(texts.len() as u64);
 
     let max_concurrent = env::var("MAX_CONCURRENT_REQUESTS")
         .ok()
@@ -275,7 +273,6 @@ where
         let api_client = api_client.clone();
         let make_request = make_request.clone();
         let embedding_provider = embedding_provider.clone();
-        let bar = bar.clone();
 
         async move {
             // Build a mask of "real" vs "empty" slots to handle providers that reject empty strings.
@@ -349,8 +346,6 @@ where
             if wait_after_request_s > 0 && i < num_batches - 1 {
                 tokio::time::sleep(Duration::from_secs(wait_after_request_s)).await;
             }
-
-            bar.inc(batch.len() as u64);
 
             Ok::<BatchResult, LLMError>(result)
         }

--- a/zqa/src/cli/handlers/cli.rs
+++ b/zqa/src/cli/handlers/cli.rs
@@ -5,12 +5,11 @@ use std::{
     sync::{Arc, Mutex, atomic},
 };
 
+use crate::utils::terminal::{BOLD, RESET};
 use crate::{
     cli::{errors::CLIError, handlers::conversation::save_current_conversation},
     common::Context,
 };
-
-use crate::utils::terminal::{BOLD, RESET};
 
 /// Save the current conversation, if needed, and prepare to exit the CLI.
 ///

--- a/zqa/src/cli/handlers/documents.rs
+++ b/zqa/src/cli/handlers/documents.rs
@@ -2,6 +2,7 @@
 
 use std::{io::Write, path::Path, sync::Arc};
 
+use tokio::sync::mpsc::UnboundedSender;
 use zqa_rag::{llm::tools::Tool, providers::registry::provider_registry};
 
 use crate::{
@@ -54,6 +55,7 @@ pub(crate) fn get_document_session_key(path: &Path) -> Result<String, CLIError> 
 /// * `LLMError::InvalidProviderError` if the provider is not supported
 pub(super) fn get_user_document_tools<O: Write, E: Write>(
     ctx: &mut Context<O, E>,
+    status_tx: UnboundedSender<String>,
 ) -> Result<Vec<Box<dyn Tool>>, CLIError> {
     let imports = ctx.state.imports.clone();
     if imports.read()?.is_empty() {
@@ -75,7 +77,7 @@ pub(super) fn get_user_document_tools<O: Write, E: Write>(
 
     Ok(
         DocumentsToolFactory::new(&imports, embedding_config, reranker_config, client)
-            .build_tools(),
+            .build_tools(status_tx),
     )
 }
 

--- a/zqa/src/cli/handlers/query.rs
+++ b/zqa/src/cli/handlers/query.rs
@@ -1,12 +1,14 @@
 //! Command handlers for query operations.
 
 use std::{
-    io::{self, Write},
+    io::Write,
     path::Path,
+    pin::pin,
     sync::{Arc, atomic},
     time::Instant,
 };
 
+use tokio::sync::mpsc;
 use zqa_rag::{
     llm::{
         base::{ApiClient, ChatHistoryContent, ChatHistoryItem, ChatRequest, MessageRole},
@@ -212,21 +214,30 @@ where
     let retrieval_embedding_tokens = std::sync::Arc::clone(&retrieval_tool.embedding_tokens);
     let retrieval_rerank_tokens = std::sync::Arc::clone(&retrieval_tool.rerank_tokens);
 
+    let (text_tx, mut text_rx) = mpsc::unbounded_channel::<String>();
+    let (status_tx, mut status_rx) = mpsc::unbounded_channel::<String>();
+    let on_text: Arc<CallbackFn<str>> = Arc::new(move |text: &str| {
+        let _ = text_tx.send(text.to_string());
+    });
+
     let summarization_tool = SummarizationTool::new(llm_client.clone(), store_arc);
     let summarization_tool_clone = summarization_tool.clone();
     let mut tools: Vec<Box<dyn Tool>> = vec![
-        Box::new(retrieval_tool.verbose().timed()),
-        Box::new(summarization_tool.verbose().timed()),
+        Box::new(
+            retrieval_tool
+                .verbose(status_tx.clone())
+                .timed(status_tx.clone()),
+        ),
+        Box::new(
+            summarization_tool
+                .verbose(status_tx.clone())
+                .timed(status_tx.clone()),
+        ),
     ];
-    let document_tools = get_user_document_tools(ctx)?;
+    let document_tools = get_user_document_tools(ctx, status_tx)?;
     tools.extend(document_tools);
 
     let chat_history = Arc::clone(&ctx.state.chat_history);
-
-    // TODO: avoid bypassing context I/O
-    let on_text: Arc<CallbackFn<str>> = Arc::new(move |text: &str| {
-        let _ = writeln!(io::stdout(), "{text}");
-    });
 
     let request = {
         let history = chat_history
@@ -244,7 +255,22 @@ where
     };
 
     let final_draft_start = Instant::now();
-    let result = llm_client.send_message(&request).await;
+    let mut send_message = pin!(llm_client.send_message(&request));
+    let result = loop {
+        tokio::select! {
+            Some(segment) = text_rx.recv() => writeln!(ctx.out, "{segment}")?,
+            Some(line) = status_rx.recv() => writeln!(ctx.err, "{line}")?,
+            result = &mut send_message => break result,
+        }
+    };
+    // Both producers can race the response's completion; drain the leftovers.
+    while let Ok(segment) = text_rx.try_recv() {
+        writeln!(ctx.out, "{segment}")?;
+    }
+    while let Ok(line) = status_rx.try_recv() {
+        writeln!(ctx.err, "{line}")?;
+    }
+
     let final_draft_duration = final_draft_start.elapsed();
 
     // Invariant: by this point, `generation_model_name` cannot be `None`.

--- a/zqa/src/tools/documents.rs
+++ b/zqa/src/tools/documents.rs
@@ -13,6 +13,7 @@ use schemars::{JsonSchema, schema_for};
 use serde::Deserialize;
 use serde_json::json;
 use thiserror::Error;
+use tokio::sync::mpsc::UnboundedSender;
 use zqa_pdftools::{
     chunk::{Chunker, ChunkingStrategy},
     parse::{ExtractedContent, extract_text},
@@ -108,15 +109,19 @@ impl DocumentsToolFactory {
 
     /// Return a list of tools to interact with the user-imported documents. As of now, all the
     /// tools are effectively pure functions in that they do not modify anything in the context.
-    pub(crate) fn build_tools(&self) -> Vec<Box<dyn Tool>> {
+    ///
+    /// # Arguments
+    ///
+    /// * `status_tx` - The channel on which the tool wrappers report their status lines.
+    pub(crate) fn build_tools(&self, status_tx: UnboundedSender<String>) -> Vec<Box<dyn Tool>> {
         vec![
             // `ListDocumentsTool` doesn't take very long since it's just a listing, so it doesn't
             // need to be `timed()`.
-            Box::new(ListDocumentsTool::new(Arc::clone(&self.ctx)).verbose()),
+            Box::new(ListDocumentsTool::new(Arc::clone(&self.ctx)).verbose(status_tx.clone())),
             Box::new(
                 QueryDocumentsTool::new(Arc::clone(&self.ctx))
-                    .verbose()
-                    .timed(),
+                    .verbose(status_tx.clone())
+                    .timed(status_tx),
             ),
         ]
     }

--- a/zqa/src/tools/mixins.rs
+++ b/zqa/src/tools/mixins.rs
@@ -1,17 +1,24 @@
 use std::{pin::Pin, time::Instant};
 
+use tokio::sync::mpsc::UnboundedSender;
 use zqa_rag::llm::tools::Tool;
 
 use crate::utils::terminal::{DIM_TEXT, RESET};
 
-/// `Tool` wrapper that prints its arguments before delegating to the wrapped tool.
+/// `Tool` wrapper that reports its arguments on a status channel before delegating to the
+/// wrapped tool.
+///
+/// The wrappers in this module send their lines over a channel rather than printing, so the
+/// consumer decides where they land: the query handler forwards them to the context's error
+/// stream, which is the terminal in the CLI and the transcript in the TUI.
 pub struct Verbose<T: Tool> {
     inner: T,
+    status_tx: UnboundedSender<String>,
 }
 
 impl<T: Tool> Verbose<T> {
-    pub fn new(inner: T) -> Self {
-        Self { inner }
+    pub fn new(inner: T, status_tx: UnboundedSender<String>) -> Self {
+        Self { inner, status_tx }
     }
 }
 
@@ -35,20 +42,28 @@ impl<T: Tool> Tool for Verbose<T> {
         Box::pin(async move {
             let printed_args = serde_json::to_string(&args).unwrap_or_default();
 
-            eprintln!("{DIM_TEXT}{} ({}){RESET}", self.inner.name(), printed_args);
+            // A send fails only when the consumer is gone, in which case the line has
+            // nowhere useful to go anyway.
+            let _ = self.status_tx.send(format!(
+                "{DIM_TEXT}{} ({}){RESET}",
+                self.inner.name(),
+                printed_args
+            ));
             self.inner.call(args).await
         })
     }
 }
 
-/// `Tool` wrapper that prints how long the wrapped tool took to run
+/// `Tool` wrapper that reports how long the wrapped tool took to run on a status channel
+/// (see [`Verbose`] for where the lines end up).
 pub struct Timed<T: Tool> {
     inner: T,
+    status_tx: UnboundedSender<String>,
 }
 
 impl<T: Tool> Timed<T> {
-    pub fn new(inner: T) -> Self {
-        Self { inner }
+    pub fn new(inner: T, status_tx: UnboundedSender<String>) -> Self {
+        Self { inner, status_tx }
     }
 }
 
@@ -74,18 +89,17 @@ impl<T: Tool> Tool for Timed<T> {
             let result = self.inner.call(args).await;
             let elapsed = start.elapsed();
 
-            match result {
-                Ok(_) => eprintln!(
-                    "{DIM_TEXT}{}{RESET} completed in {:.2}s",
-                    self.inner.name(),
-                    elapsed.as_secs_f64()
-                ),
-                Err(_) => eprintln!(
-                    "{DIM_TEXT}{}{RESET} failed after {:.2}s",
-                    self.inner.name(),
-                    elapsed.as_secs_f64()
-                ),
-            }
+            let outcome = if result.is_ok() {
+                "completed in"
+            } else {
+                "failed after"
+            };
+            let _ = self.status_tx.send(format!(
+                "{DIM_TEXT}{}{RESET} {} {:.2}s",
+                self.inner.name(),
+                outcome,
+                elapsed.as_secs_f64()
+            ));
 
             result
         })
@@ -134,18 +148,21 @@ impl<T: Tool> Tool for Timed<T> {
 ///        # }
 ///    }
 ///
+///    let (status_tx, _status_rx) = tokio::sync::mpsc::unbounded_channel();
 ///    let tool: Box<dyn Tool> = Box::new(
-///        Foo::new().verbose().timed()
+///        Foo::new().verbose(status_tx.clone()).timed(status_tx)
 ///    );
 ///    let _future = tool.call(serde_json::Value::Null);
 /// ```
 pub trait ToolExt: Tool + Sized {
-    fn verbose(self) -> Verbose<Self> {
-        Verbose::new(self)
+    /// Report the tool's arguments on `status_tx` before each call.
+    fn verbose(self, status_tx: UnboundedSender<String>) -> Verbose<Self> {
+        Verbose::new(self, status_tx)
     }
 
-    fn timed(self) -> Timed<Self> {
-        Timed::new(self)
+    /// Report each call's duration and outcome on `status_tx`.
+    fn timed(self, status_tx: UnboundedSender<String>) -> Timed<Self> {
+        Timed::new(self, status_tx)
     }
 }
 
@@ -193,57 +210,75 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verbose_forwards_call_to_inner_tool() {
+    async fn verbose_forwards_call_and_reports_args() {
         let seen_args = Arc::new(Mutex::new(None));
+        let (status_tx, mut status_rx) = tokio::sync::mpsc::unbounded_channel();
         let tool = MockTool {
             seen_args: Arc::clone(&seen_args),
         }
-        .verbose();
+        .verbose(status_tx);
 
         let args = json!({ "foo": "bar" });
         let result = tool.call(args.clone()).await.unwrap();
 
         assert_eq!(result, json!({ "ok": true }));
         assert_eq!(*seen_args.lock().unwrap(), Some(args));
+
+        let line = status_rx.try_recv().unwrap();
+        assert!(line.contains("mock_tool"));
+        assert!(line.contains(r#"{"foo":"bar"}"#));
     }
 
     #[tokio::test]
-    async fn timed_forwards_call_to_inner_tool() {
+    async fn timed_forwards_call_and_reports_duration() {
         let seen_args = Arc::new(Mutex::new(None));
+        let (status_tx, mut status_rx) = tokio::sync::mpsc::unbounded_channel();
         let tool = MockTool {
             seen_args: Arc::clone(&seen_args),
         }
-        .timed();
+        .timed(status_tx);
 
         let args = json!({ "foo": "bar" });
         let result = tool.call(args.clone()).await.unwrap();
 
         assert_eq!(result, json!({ "ok": true }));
         assert_eq!(*seen_args.lock().unwrap(), Some(args));
+
+        let line = status_rx.try_recv().unwrap();
+        assert!(line.contains("mock_tool"));
+        assert!(line.contains("completed in"));
     }
 
     #[tokio::test]
-    async fn chained_wrappers_forward_call_to_inner_tool() {
+    async fn chained_wrappers_forward_call_and_report_in_order() {
         let seen_args = Arc::new(Mutex::new(None));
+        let (status_tx, mut status_rx) = tokio::sync::mpsc::unbounded_channel();
         let tool = MockTool {
             seen_args: Arc::clone(&seen_args),
         }
-        .verbose()
-        .timed();
+        .verbose(status_tx.clone())
+        .timed(status_tx);
 
         let args = json!({ "foo": "bar" });
         let result = tool.call(args.clone()).await.unwrap();
 
         assert_eq!(result, json!({ "ok": true }));
         assert_eq!(*seen_args.lock().unwrap(), Some(args));
+
+        // The argument announcement precedes the timing line.
+        let first = status_rx.try_recv().unwrap();
+        let second = status_rx.try_recv().unwrap();
+        assert!(first.contains(r#"{"foo":"bar"}"#));
+        assert!(second.contains("completed in"));
     }
 
     #[test]
     fn verbose_delegates_metadata() {
+        let (status_tx, _status_rx) = tokio::sync::mpsc::unbounded_channel();
         let tool = MockTool {
             seen_args: Arc::new(Mutex::new(None)),
         }
-        .verbose();
+        .verbose(status_tx);
 
         assert_eq!(tool.name(), "mock_tool");
         assert_eq!(tool.description(), "A mock tool");
@@ -251,10 +286,11 @@ mod tests {
 
     #[test]
     fn timed_delegates_metadata() {
+        let (status_tx, _status_rx) = tokio::sync::mpsc::unbounded_channel();
         let tool = MockTool {
             seen_args: Arc::new(Mutex::new(None)),
         }
-        .timed();
+        .timed(status_tx);
 
         assert_eq!(tool.name(), "mock_tool");
         assert_eq!(tool.description(), "A mock tool");


### PR DESCRIPTION
## Problem

A TUI feature is planned, but is partially blocked by direct writes to `stdout` and `stderr`.

## Solution

Replace `Context` I/O bypass with a channel and `tokio::select` idiom. Also remove progress bars in libraries, which was against the style guide anyway.