### PR TITLE
docs: add OKF wiki

### DIFF
--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -1,0 +1,63 @@
+---
+type: Crate
+title: zqa CLI
+description: The interactive application that processes Zotero libraries, manages sessions, and orchestrates search and RAG queries.
+tags: [cli, zotero, rag]
+timestamp: 2026-07-12T19:56:20-07:00
+---
+
+# Startup and state
+
+`zqa/src/main.rs` loads `.env` and starts the Tokio runtime. `zqa::run` sets a
+state-directory LanceDB location when `LANCEDB_URI` is not already set, loads
+[runtime configuration](/configuration.md), performs first-run setup when
+needed, creates a `LanceZoteroStore`, and enters the interactive CLI.
+
+The REPL uses `rustyline` with history in `~/.zqa_history`. It keeps the
+current chat history, title, imported documents, and session state in the
+application context; interrupting the REPL saves the current conversation.
+
+# Commands
+
+| Command | Purpose |
+| --- | --- |
+| `/process` | Read new Zotero items, parse their PDFs, and add embeddings to the local store. |
+| `/embed` and `/embed fix` | Resume a saved embedding batch or repair zero-vector rows. |
+| `/search <query>` | Run vector retrieval and print paper titles without generation. |
+| Natural-language input | Run a full RAG query; inputs shorter than ten characters are rejected as accidental prompts. |
+| `/index`, `/dedup`, `/stats` | Maintain and inspect the local vector store. |
+| `/checkhealth`, `/doctor` | Inspect storage health and diagnose database problems. |
+| `/new`, `/resume` | Start a fresh conversation or load a saved one. |
+| `/docs list`, `/docs remove <key>`, `/docs clear` | Inspect or remove session-scoped imported PDFs. |
+| `/batch create`, `/batch check`, `/batch cancel <id>` | Manage supported provider batch-embedding jobs. |
+| `/config`, `/help`, `/quit` | Display configuration, help, or leave the REPL. |
+
+# Library processing
+
+`/process` reads Zotero metadata, converts parsed PDFs to Arrow record batches,
+and asks `LanceZoteroStore` to embed and upsert them. Before the upsert, it
+writes the batch to `batch_iter.bin`. If embedding fails, that recovery file is
+kept so `/embed` can replay the parsed records rather than parsing the library
+again.
+
+The store is the application-specific layer over [zqa-rag](/rag.md)'s
+`LanceBackend`. Its records include Zotero library keys, titles, PDF paths, and
+PDF text.
+
+# Query execution
+
+`/search` retrieves up to ten results through the local store and optionally
+reranks them. A natural-language query constructs an LLM request with retrieval
+and summarization tools, plus tools for any session-imported PDFs. The CLI
+streams model text and tool status to the terminal, then records the completed
+turn and its token and cost information in session state.
+
+Imported PDFs are parsed with [zqa-pdftools](/pdf-processing.md), but live only
+for the current session. This lets a question refer to a local PDF without
+adding it to Zotero or the vector index.
+
+# Related concepts
+
+[System overview](/system-overview.md) describes the full data flow.
+[Runtime configuration](/configuration.md) documents provider selection, and
+[macros](/macros.md) documents the test helpers used by this crate.

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -1,0 +1,48 @@
+---
+type: Configuration
+title: Runtime Configuration
+description: Provider settings, API credentials, and runtime defaults loaded from user configuration and environment variables.
+tags: [configuration, providers, security]
+timestamp: 2026-07-12T19:58:42-07:00
+---
+
+# Configuration sources
+
+The user configuration file is `~/.config/zqa/config.toml`. It selects the
+providers and models used for generation, embeddings, and optional reranking,
+along with runtime limits such as concurrent requests and retries. At startup,
+`zqa` loads TOML values and then overwrites supported values from the
+environment. Its executable loads a local `.env` file first, so it
+can supply those environment values without putting credentials in TOML.
+
+Keep real credentials out of version control. A configuration file that is
+managed with dotfiles should leave secret values blank and rely on environment
+variables or a local `.env` file instead.
+
+# Provider roles
+
+| Role | Purpose |
+| --- | --- |
+| Generation | Produces conversational answers and tool calls. |
+| Embedding | Converts library chunks and queries into vectors for retrieval. |
+| Reranking | Optionally refines retrieved results before they reach the answer model. |
+
+The provider registry supports Anthropic, OpenAI, OpenRouter, Gemini, and
+Ollama for generation; OpenAI, Voyage AI, Cohere, ZeroEntropy, Gemini, and
+Ollama for embeddings; and Voyage AI, Cohere, and ZeroEntropy for reranking.
+Reranking is disabled when `reranker_provider` is omitted. Model names,
+dimensions, token limits, and provider-specific options belong to each
+provider's configuration section. See [zqa-rag](/rag.md) for the provider and
+retrieval abstractions.
+
+# Operational settings
+
+`max_concurrent_requests` controls concurrent embedding requests, while
+`max_retries` controls retries after network failures. `LANCEDB_URI` overrides
+the database location. When it is unset, the CLI places the database under its
+state directory before initializing the vector store.
+
+# Related concepts
+
+[System overview](/system-overview.md) shows where these choices affect the
+runtime pipeline. [The CLI](/cli.md) owns user-facing setup and command flows.

--- a/wiki/development.md
+++ b/wiki/development.md
@@ -1,0 +1,56 @@
+---
+type: Development Guide
+title: Development Workflow
+description: Workspace layout, local requirements, and commands for building, testing, and linting the project.
+tags: [development, rust, ci]
+timestamp: 2026-07-12T19:49:45-07:00
+---
+
+# Workspace
+
+The Cargo workspace contains five crates:
+
+| Crate | Role |
+| --- | --- |
+| `zqa` | Command-line application. |
+| `zqa-rag` | RAG, provider, and vector-storage library. |
+| `zqa-pdftools` | PDF parsing and text-extraction library. |
+| `zqa-macros` | Declarative macro crate. |
+| `zqa-macros-proc` | Procedural macro crate. |
+
+See [system overview](/system-overview.md) for their runtime relationship and
+[macros](/macros.md) for the supporting crates.
+
+# Local requirements
+
+Use Rust 2024 edition or later. A local Zotero library and provider credentials
+are needed for end-to-end use; see [runtime configuration](/configuration.md).
+On Linux, `.cargo/config.toml` uses the `mold` linker for faster linking. Install
+`mold` or remove that linker setting when it is unavailable.
+
+Some CI jobs install `protobuf-compiler` before building. The continuous
+integration checks also run formatting, Clippy with warnings denied, and
+`cargo-deny` dependency checks.
+
+# Common commands
+
+| Purpose | Command |
+| --- | --- |
+| Build a release binary | `cargo build --release` |
+| Run the CLI | `cargo run --bin zqa` |
+| Test the workspace | `cargo test --workspace` |
+| Test one crate | `cargo test -p zqa-rag` |
+| Format | `cargo fmt --all` |
+| Check formatting | `cargo fmt --all -- --check` |
+| Lint | `cargo clippy --all-targets --all-features -- -D warnings` |
+| Benchmark PDF tools | `cargo bench -p zqa-pdftools` |
+
+# Test notes
+
+Integration tests in `zqa/tests/` are disabled by default and use the
+`INTEGRATION_TESTS` environment variable. When debugging PDF behavior, the
+ignored PDF diagnostics can be run with `cargo test -p zqa-pdftools <test_name>
+-- --ignored --nocapture`.
+
+Do not commit API keys. Keep secrets in `.env` or the user configuration file,
+and use `RUST_BACKTRACE=1` when investigating Rust failures.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,20 @@
+---
+okf_version: "0.1"
+source_commit: f47a18f77f5209c956dc5da83a0e6dd5729771eb
+---
+
+# Zotero RAG QA System
+
+* [Zotero RAG QA System](system-overview.md) - A Rust command-line system that indexes a local Zotero library and answers grounded questions over its PDFs.
+
+# Application and libraries
+
+* [zqa CLI](cli.md) - The interactive application that processes Zotero libraries, manages sessions, and orchestrates search and RAG queries.
+* [zqa-rag](rag.md) - The reusable library for provider clients, embeddings, reranking, and LanceDB-backed vector retrieval.
+* [zqa-pdftools](pdf-processing.md) - The academic-PDF parser that extracts structured text, detects sections, and produces retrieval chunks.
+* [zqa Test Macros](macros.md) - Test-support crates that provide diagnostic assertions and retrying asynchronous test helpers.
+
+# Operations
+
+* [Runtime Configuration](configuration.md) - Provider settings, API credentials, and runtime defaults loaded from user configuration and environment variables.
+* [Development Workflow](development.md) - Workspace layout, local requirements, and commands for building, testing, and linting the project.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,6 @@
+# Update Log
+
+## 2026-07-12
+* **Update**: Clarified configuration source precedence and the default database location.
+* **Creation**: Added a system, component, configuration, and development reference for the workspace.
+* **Initialization**: Created bundle structure.

--- a/wiki/macros.md
+++ b/wiki/macros.md
@@ -1,0 +1,39 @@
+---
+type: Supporting Crates
+title: zqa Test Macros
+description: Test-support crates that provide diagnostic assertions and retrying asynchronous test helpers.
+tags: [testing, macros, rust]
+timestamp: 2026-07-12T19:56:20-07:00
+---
+
+# zqa-macros
+
+`zqa-macros` exports declarative test assertions with more useful failure
+output than their minimal equivalents:
+
+| Macro | Check |
+| --- | --- |
+| `test_eq!` | Equality, printing received and expected values on failure. |
+| `test_contains!` | Membership in a container that supports `contains`. |
+| `test_contains_all!` | Membership of every value in an iterable. |
+| `test_ok!` | That a `Result` is `Ok`, including the error in a failing message. |
+
+The macros borrow their operands before checking them, which avoids evaluating
+an expression twice.
+
+# zqa-macros-proc
+
+`zqa-macros-proc` currently exports `#[retry(n)]` for asynchronous tests. It
+requires a positive retry count and an `async fn`; each attempt catches a panic
+and retries until the final attempt, which rethrows the panic normally.
+
+Place `#[retry(n)]` before `#[tokio::test]` so the retry wrapper is applied
+first. The attribute is intended for tests with transient failures, not for
+hiding deterministic regressions.
+
+# Usage in the workspace
+
+The macros are used by tests in [zqa-pdftools](/pdf-processing.md) and the
+[zqa CLI](/cli.md). They are support crates rather than part of the runtime RAG
+pipeline; see [system overview](/system-overview.md) for the application and
+library boundaries.

--- a/wiki/pdf-processing.md
+++ b/wiki/pdf-processing.md
@@ -1,0 +1,65 @@
+---
+type: Crate
+title: zqa-pdftools
+description: The academic-PDF parser that extracts structured text, detects sections, and produces retrieval chunks.
+tags: [pdf, parsing, chunking]
+timestamp: 2026-07-12T19:56:20-07:00
+---
+
+# Purpose
+
+`zqa-pdftools` extracts text from academic PDFs for the retrieval pipeline. Its
+parser is tuned for papers: it skips images and uses heuristics to remove table
+content, recognizes common Computer Modern math fonts, and records
+font-derived section boundaries.
+
+# Extraction pipeline
+
+| Stage | Responsibility |
+| --- | --- |
+| Load pages | `extract_text` loads the PDF with `lopdf` and processes each page. |
+| Tokenize content streams | `tokenizer` recognizes PDF literals, hex strings, names, numbers, and operators. |
+| Decode text | `parse` handles text operators and spacing; `fonts` resolves simple and CID-keyed encodings, including ToUnicode CMaps. |
+| Repair and classify | Edits repair ligatures and script markers; font size and boldness identify section boundaries. |
+| Produce content | `ExtractedContent` returns text, section boundaries, and page count. |
+
+For supported Computer Modern fonts, math mappings convert selected symbols to
+LaTeX. Section levels are inferred from font sizes, and only the first four
+levels are retained.
+
+# Chunking
+
+`Chunker` turns `ExtractedContent` into `DocumentChunk` values with a
+one-based chunk ID, total chunk count, text, byte range, page range, and the
+strategy used. Two strategies are available:
+
+| Strategy | Behavior |
+| --- | --- |
+| `WholeDocument` | Keep the complete extracted document in one chunk. |
+| `SectionBased(max_chars)` | Preserve detected section boundaries where possible and split text to the maximum character budget. |
+
+Embedding providers can recommend a strategy, but callers remain free to
+choose one. [The CLI](/cli.md) uses these chunks when it processes Zotero and
+session-imported PDFs for [zqa-rag](/rag.md).
+
+# Heuristics and limits
+
+Table detection relies on text-position operators and alignment thresholds, so
+unusual tables or multi-column layouts can be misclassified. Font and CMap
+coverage varies by PDF; CID-keyed fonts without usable ToUnicode data cannot be
+decoded reliably. Spacing, superscripts, and subscripts are heuristic, and
+complex mathematical environments such as `bmatrix`, `cases`, and `align` can
+extract poorly.
+
+# Diagnostics
+
+Ignored debugging tests in `parse.rs` print raw page content, inspect font
+properties and CMaps, or show content around anchor text. Run one with:
+
+```sh
+cargo test -p zqa-pdftools <test_name> -- --ignored --nocapture
+```
+
+The crate also has Criterion benchmarks for parsing throughput. See
+[development workflow](/development.md) for the standard benchmark command and
+[macros](/macros.md) for test helpers used by the parser tests.

--- a/wiki/rag.md
+++ b/wiki/rag.md
@@ -1,0 +1,69 @@
+---
+type: Crate
+title: zqa-rag
+description: The reusable library for provider clients, embeddings, reranking, and LanceDB-backed vector retrieval.
+tags: [rag, providers, lancedb]
+timestamp: 2026-07-12T19:56:20-07:00
+---
+
+# Responsibilities
+
+`zqa-rag` separates provider-specific API details from the application. It
+owns configuration types, LLM client creation, embedding and reranking
+factories, the vector-backend abstraction, LanceDB integration, pricing, and
+storage diagnostics. [The CLI](/cli.md) supplies Zotero-specific records and
+user interaction on top of those interfaces.
+
+# Provider registry
+
+`ProviderRegistry` maps a canonical `ProviderId` to factories for each
+capability. A provider configuration selects a factory, which creates one of
+these objects:
+
+| Capability | Registered providers |
+| --- | --- |
+| Generation | Anthropic, OpenAI, OpenRouter, Gemini, Ollama |
+| Embeddings | OpenAI, Voyage AI, Cohere, ZeroEntropy, Gemini, Ollama |
+| Reranking | Voyage AI, Cohere, ZeroEntropy |
+| Batch embeddings | Voyage AI |
+
+The registry also registers embedding implementations with LanceDB. This keeps
+provider selection in configuration rather than in application-specific code.
+
+# LLM and tool interface
+
+`ApiClient` implementations send `ChatRequest` values and return normalized
+completion responses. A request can include chat history, reasoning settings,
+streaming callbacks, and a list of `Tool` trait objects. Each tool supplies a
+name, description, JSON Schema for its arguments, and an asynchronous call.
+Provider adapters serialize that shared interface into their own tool schema
+format.
+
+The CLI uses this interface for retrieval, paper summarization, and
+session-imported document tools.
+
+# Retrieval pipeline
+
+Embedding providers implement LanceDB's embedding-function interface. The
+common embedding layer selects a provider from `EmbeddingProviderConfig` and
+handles shared batching behavior. Rerankers implement the `Rerank` trait,
+which returns result ordering for a query and candidate texts.
+
+`VectorBackend` is the generic persistence boundary: it defines connection,
+indexing, insertion, deduplication, metadata, and vector-search operations.
+`LanceBackend` is the current implementation. It stores data and metadata
+tables, records the embedding provider and model, and tracks data-table version
+drift so health checks can detect out-of-band updates.
+
+# Storage operations
+
+The LanceDB URI is configurable through `LANCEDB_URI`. The library exposes
+health and doctor modules for checking table access, size, row counts,
+zero-vector rows, index state, and version drift. The CLI surfaces these
+operations through `/checkhealth` and `/doctor`.
+
+# Related concepts
+
+[Runtime configuration](/configuration.md) selects providers and models.
+[PDF processing](/pdf-processing.md) produces the text chunks that the
+application converts into vector-store records.

--- a/wiki/system-overview.md
+++ b/wiki/system-overview.md
@@ -1,0 +1,42 @@
+---
+type: System
+title: Zotero RAG QA System
+description: A Rust command-line system that indexes a local Zotero library and answers grounded questions over its PDFs.
+tags: [zotero, rag, rust]
+timestamp: 2026-07-12T19:56:20-07:00
+---
+
+# Purpose
+
+`zqa` makes a local Zotero library searchable and queryable with natural-language
+questions. It combines PDF text extraction, semantic indexing, optional
+reranking, and model-generated answers grounded in retrieved library content.
+
+# End-to-end flow
+
+1. The user configures generation, embedding, and optional reranking providers.
+2. The CLI processes Zotero entries and their PDFs.
+3. [zqa-pdftools](/pdf-processing.md) extracts text and splits it into chunks.
+4. [zqa-rag](/rag.md) embeds those chunks and persists searchable vectors in
+   LanceDB.
+5. A search or conversation retrieves relevant chunks; an LLM uses that context
+   and its available tools to produce a response. Search-only mode returns
+   relevant papers without generating an answer.
+
+# Workspace boundaries
+
+| Crate | Responsibility |
+| --- | --- |
+| [zqa](/cli.md) | Interactive command-line application, session state, library processing, and query orchestration. |
+| [zqa-rag](/rag.md) | Reusable provider clients, embeddings, reranking, and vector retrieval. |
+| [zqa-pdftools](/pdf-processing.md) | PDF parsing, text extraction, and chunking for academic papers. |
+| [zqa-macros](/macros.md) | Declarative test assertions with diagnostic output. |
+| [zqa-macros-proc](/macros.md) | Procedural test helpers, including the async `#[retry]` attribute. |
+
+# Operating model
+
+The vector index is stored locally in LanceDB. Generation, embedding, and
+reranking can use local or hosted providers, so credentials and model choices
+belong in [runtime configuration](/configuration.md), not in the repository.
+See the [development workflow](/development.md) for local build and test
+commands.


### PR DESCRIPTION
Creates an initial version of a wiki for agents in the [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) for agents' use.