### PR TITLE
feat(pdftools): ignore text from CID-keyed fonts without `ToUnicode` map

### DIFF
--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -130,6 +130,10 @@ pub(crate) enum FontEncoding {
     /// two-byte (or multi-byte, but we don't yet handle this) CIDs, custom glyph ID maps, and
     /// `ToUnicode` CMaps for real text extraction.
     CIDKeyed(CMap),
+    /// A CID-keyed font with no `ToUnicode` CMap. Text in such fonts cannot be reliably
+    /// extracted, so instead of erroring out, the parser skips text set in these fonts and
+    /// records how much was skipped.
+    Unmappable,
 }
 
 /// CMaps can take two main forms: individual, where `beginbfchar` and `endbfchar` wrap a set of
@@ -365,7 +369,6 @@ pub(crate) fn parse_cmap(cmap: &str, font_key: &str) -> Result<HashMap<String, S
 /// * `PdfError::FontNotFound` if the font key does not exist.
 /// * `PdfError::EncodingError` if the font dictionary:
 ///      * Has an /Encoding that could not be read
-///      * Indicates a CID-keyed font but does not have a ToUnicode CMap.
 ///      * Has a ToUnicode CMap that could not be read or deflated.
 ///      * Has a ToUnicode CMap without a `beginbfchar`, `endbfchar`, `beginbfrange`, or
 ///        `endbfrange` marker.
@@ -439,17 +442,18 @@ pub(crate) fn compute_font_encoding(
         // Test 3: if the font has:
         //   /Subtype /Type0
         // then it is likely a CID-keyed font.
-        let cmap_ref = font_obj
-            .get("ToUnicode")
-            .ok_or(PdfError::EncodingError(format!(
-                "CID-keyed font {font_key} does not have a ToUnicode CMap.",
-            )))?
-            .as_reference()
-            .map_err(|_| {
-                PdfError::EncodingError(format!(
-                    "CID-keyed font {font_key}'s ToUnicode CMap could not be read."
-                ))
-            })?;
+        let Some(to_unicode) = font_obj.get("ToUnicode") else {
+            log::debug!(
+                "CID-keyed font {font_key} does not have a ToUnicode CMap; text using it will be skipped."
+            );
+            return Ok(FontEncoding::Unmappable);
+        };
+
+        let cmap_ref = to_unicode.as_reference().map_err(|_| {
+            PdfError::EncodingError(format!(
+                "CID-keyed font {font_key}'s ToUnicode CMap could not be read."
+            ))
+        })?;
 
         let decompressed = doc
             .get_object(cmap_ref)

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -567,10 +567,15 @@ impl PdfParser {
                             log::warn!("Unexpected Hex token in simple font");
                         }
                         FontEncoding::Unmappable => {
-                            // CIDs are two bytes each, encoded as four hex characters; use the
+                            // CIDs are two bytes each, encoded as four hex digits; use the
                             // number of skipped CIDs as an estimate of skipped characters.
-                            let num_cids =
-                                std::str::from_utf8(hex_str).unwrap_or("").len().div_ceil(4);
+                            // Whitespace is permitted inside PDF hex strings, so count only
+                            // hex digits to avoid inflating the estimate.
+                            let num_cids = hex_str
+                                .iter()
+                                .filter(|b| b.is_ascii_hexdigit())
+                                .count()
+                                .div_ceil(4);
                             log::debug!(
                                 "Skipping {num_cids} CID(s) of text in unmappable font {font_id}"
                             );
@@ -1565,12 +1570,19 @@ mod tests {
             ..PdfParser::default()
         };
 
-        // 8 hex chars = 2 CIDs; 4 literal bytes = 2 CIDs.
+        // 8 hex digits = 2 CIDs; 4 literal bytes = 2 CIDs.
         let tokens = vec![Token::Hex(b"ABCD1234"), Token::Literal(b"ABCD")];
         let (text, skipped) = parser.process_tj_tokens(&tokens, &doc, page_id).unwrap();
 
         test_eq!(skipped, 4);
         assert!(text.trim().is_empty(), "Expected no text, got {text:?}");
+
+        // Whitespace inside a hex string is permitted by the PDF spec and must not inflate the
+        // skipped count: this is still 8 hex digits = 2 CIDs.
+        let tokens = vec![Token::Hex(b"AB CD 12\n34")];
+        let (_, skipped) = parser.process_tj_tokens(&tokens, &doc, page_id).unwrap();
+
+        test_eq!(skipped, 2);
     }
 
     #[test]

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -271,6 +271,9 @@ struct ParseResult {
     font_size_markers: Vec<FontSizeMarker>,
     /// Body font size
     body_font_size: Option<f32>,
+    /// The number of characters that were skipped on this page because they used CID-keyed fonts
+    /// without a usable `ToUnicode` CMap.
+    skipped_chars: usize,
 }
 
 impl PdfParser {
@@ -309,7 +312,6 @@ impl PdfParser {
     /// * `PdfError::FontNotFound` if the font key does not exist.
     /// * `PdfError::EncodingError` if the font dictionary:
     ///      * Has an /Encoding that could not be read
-    ///      * Indicates a CID-keyed font but does not have a ToUnicode CMap.
     ///      * Has a ToUnicode CMap that could not be read or deflated.
     ///      * Has a ToUnicode CMap without a `beginbfchar` or `endbfchar` marker.
     /// * `PdfError::InternalError` if the font dictionary:
@@ -471,23 +473,27 @@ impl PdfParser {
     ///
     /// # Returns
     ///
-    /// The extracted text string with proper spacing applied
+    /// A tuple of the extracted text string with proper spacing applied, and the number of
+    /// characters that were skipped because the current font is CID-keyed but has no usable
+    /// `ToUnicode` CMap (an estimate based on the number of CIDs skipped).
     ///
     /// # Errors
     ///
     /// Returns an error if font information cannot be retrieved
+    #[allow(clippy::too_many_lines)]
     fn process_tj_tokens(
         &mut self,
         tokens: &[Token<'_>],
         doc: &Document,
         page_id: PageID,
-    ) -> Result<String, PdfError> {
+    ) -> Result<(String, usize), PdfError> {
         let mut result = String::new();
+        let mut skipped_chars = 0;
         let font_id = self.cur_font_id.clone();
 
         // Skip if we don't have a valid font ID yet
         if font_id.is_empty() {
-            return Ok(result);
+            return Ok((result, skipped_chars));
         }
 
         let cur_font = self.cur_font.clone();
@@ -512,6 +518,13 @@ impl PdfParser {
                         FontEncoding::CIDKeyed(_) => {
                             // This shouldn't happen - CID-keyed fonts use Hex tokens
                             log::warn!("Unexpected Literal token in CID-keyed font");
+                        }
+                        FontEncoding::Unmappable => {
+                            log::debug!(
+                                "Skipping {} byte(s) of text in unmappable font {font_id}",
+                                text.len()
+                            );
+                            skipped_chars += text.len();
                         }
                     }
 
@@ -551,6 +564,16 @@ impl PdfParser {
                         FontEncoding::Simple => {
                             log::warn!("Unexpected Hex token in simple font");
                         }
+                        FontEncoding::Unmappable => {
+                            // CIDs are two bytes each, encoded as four hex characters; use the
+                            // number of skipped CIDs as an estimate of skipped characters.
+                            let num_cids =
+                                std::str::from_utf8(hex_str).unwrap_or("").len().div_ceil(4);
+                            log::debug!(
+                                "Skipping {num_cids} CID(s) of text in unmappable font {font_id}"
+                            );
+                            skipped_chars += num_cids;
+                        }
                     }
 
                     // Check for spacing after this hex string
@@ -580,7 +603,7 @@ impl PdfParser {
             i += 1;
         }
 
-        Ok(result)
+        Ok((result, skipped_chars))
     }
 
     /// Given a token slice and an index `pos` of an `ET` token, look *around* `pos` and search for
@@ -721,6 +744,7 @@ impl PdfParser {
         let mut parsed = String::new();
 
         let tokens = tokenize(&content);
+        let mut skipped_chars = 0;
 
         // Keep track of the font sizes markers (from Tf) and associated positions
         let mut tf_history: Vec<FontSizeMarker> = Vec::new();
@@ -770,8 +794,10 @@ impl PdfParser {
                 }
                 Token::Op(b"TJ") => {
                     if let Some(start_idx) = tj_start_idx {
-                        parsed +=
-                            &self.process_tj_tokens(&tokens[start_idx..token_idx], doc, page_id)?;
+                        let (text, skipped) =
+                            self.process_tj_tokens(&tokens[start_idx..token_idx], doc, page_id)?;
+                        parsed += &text;
+                        skipped_chars += skipped;
                         tj_start_idx = None;
                     }
                 }
@@ -858,6 +884,7 @@ impl PdfParser {
             content: parsed,
             font_size_markers: tf_history,
             body_font_size,
+            skipped_chars,
         })
     }
 }
@@ -932,6 +959,7 @@ pub fn extract_text(file_path: &str) -> Result<ExtractedContent, Box<dyn Error>>
     let mut full_text = String::new();
     let mut sections = Vec::new();
     let mut body_font_size: Option<f32> = None;
+    let mut skipped_chars_total = 0;
 
     let page_count = doc.get_pages().len();
 
@@ -966,6 +994,20 @@ pub fn extract_text(file_path: &str) -> Result<ExtractedContent, Box<dyn Error>>
         }
 
         full_text.push_str(&result.content);
+        skipped_chars_total += result.skipped_chars;
+    }
+
+    if skipped_chars_total > 0 {
+        let total = skipped_chars_total + full_text.len();
+        let pct = 100.0 * (skipped_chars_total as f64) / (total as f64);
+
+        // Decide on a log level based on `pct`; we don't want to alarm users needlessly.
+        // TODO: Consider making this part of [`PdfParserThresholds`]
+        if pct >= 5.0 {
+            log::warn!(
+                "Skipped {skipped_chars_total} character(s) ({pct:.1}% of the document): text uses CID-keyed fonts with no usable ToUnicode CMap and could not be extracted."
+            );
+        }
     }
 
     let mut font_sizes = sections
@@ -1416,7 +1458,7 @@ mod tests {
         let result = parser.process_tj_tokens(&tokens, &doc, page_id);
         assert!(result.is_ok(), "process_tj_tokens failed: {result:?}");
 
-        let text = result.unwrap();
+        let (text, _) = result.unwrap();
         assert!(text.contains("Hello"));
         assert!(text.contains("World"));
     }

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -520,11 +520,13 @@ impl PdfParser {
                             log::warn!("Unexpected Literal token in CID-keyed font");
                         }
                         FontEncoding::Unmappable => {
+                            // In a CID-keyed font, literal strings contain two-byte character
+                            // codes, so halve the byte count to estimate skipped characters.
+                            let num_cids = text.len().div_ceil(2);
                             log::debug!(
-                                "Skipping {} byte(s) of text in unmappable font {font_id}",
-                                text.len()
+                                "Skipping {num_cids} CID(s) of text in unmappable font {font_id}"
                             );
-                            skipped_chars += text.len();
+                            skipped_chars += num_cids;
                         }
                     }
 
@@ -998,13 +1000,17 @@ pub fn extract_text(file_path: &str) -> Result<ExtractedContent, Box<dyn Error>>
     }
 
     if skipped_chars_total > 0 {
-        let total = skipped_chars_total + full_text.len();
+        let total = skipped_chars_total + full_text.chars().count();
         let pct = 100.0 * (skipped_chars_total as f64) / (total as f64);
 
         // Decide on a log level based on `pct`; we don't want to alarm users needlessly.
         // TODO: Consider making this part of [`PdfParserThresholds`]
         if pct >= 5.0 {
             log::warn!(
+                "Skipped {skipped_chars_total} character(s) ({pct:.1}% of the document): text uses CID-keyed fonts with no usable ToUnicode CMap and could not be extracted."
+            );
+        } else {
+            log::debug!(
                 "Skipped {skipped_chars_total} character(s) ({pct:.1}% of the document): text uses CID-keyed fonts with no usable ToUnicode CMap and could not be extracted."
             );
         }
@@ -1234,7 +1240,7 @@ mod tests {
             text[content.sections.get(3).unwrap().byte_index..][..10].to_string(),
             "1.1 subsec"
         );
-        assert_eq!(
+        test_eq!(
             text[content.sections.get(4).unwrap().byte_index..][..15].to_string(),
             "1.1.1 subsubsec"
         );
@@ -1461,6 +1467,110 @@ mod tests {
         let (text, _) = result.unwrap();
         assert!(text.contains("Hello"));
         assert!(text.contains("World"));
+    }
+
+    /// Build a minimal in-memory PDF with a single page whose content stream is `content`,
+    /// using a Type0 font (`F1`) with an Identity-H encoding and no `ToUnicode` CMap.
+    fn doc_with_unmappable_type0_font(content: &[u8]) -> (Document, PageID) {
+        let mut doc = Document::with_version("1.5");
+
+        let font_id = doc.add_object(lopdf::Dictionary::from_iter(vec![
+            ("Type", lopdf::Object::Name(b"Font".to_vec())),
+            ("Subtype", lopdf::Object::Name(b"Type0".to_vec())),
+            ("BaseFont", lopdf::Object::Name(b"FakeFont".to_vec())),
+            ("Encoding", lopdf::Object::Name(b"Identity-H".to_vec())),
+        ]));
+
+        let content_id = doc.add_object(lopdf::Stream::new(
+            lopdf::Dictionary::new(),
+            content.to_vec(),
+        ));
+
+        let fonts = lopdf::Dictionary::from_iter(vec![(b"F1", lopdf::Object::Reference(font_id))]);
+        let resources_id = doc.add_object(lopdf::Dictionary::from_iter(vec![(
+            "Font",
+            lopdf::Object::Dictionary(fonts),
+        )]));
+
+        let page_obj_id = doc.add_object(lopdf::Dictionary::from_iter(vec![
+            ("Type", lopdf::Object::Name(b"Page".to_vec())),
+            ("Resources", lopdf::Object::Reference(resources_id)),
+            ("Contents", lopdf::Object::Reference(content_id)),
+        ]));
+
+        let pages_id = doc.add_object(lopdf::Dictionary::from_iter(vec![
+            ("Type", lopdf::Object::Name(b"Pages".to_vec())),
+            (
+                "Kids",
+                lopdf::Object::Array(vec![lopdf::Object::Reference(page_obj_id)]),
+            ),
+            ("Count", lopdf::Object::Integer(1)),
+        ]));
+
+        if let Ok(lopdf::Object::Dictionary(page)) = doc.get_object_mut(page_obj_id) {
+            page.set("Parent", pages_id);
+        }
+
+        let catalog_id = doc.add_object(lopdf::Dictionary::from_iter(vec![
+            ("Type", lopdf::Object::Name(b"Catalog".to_vec())),
+            ("Pages", lopdf::Object::Reference(pages_id)),
+        ]));
+        doc.trailer.set("Root", catalog_id);
+
+        (doc, page_obj_id)
+    }
+
+    #[test]
+    fn test_type0_font_without_tounicode_is_unmappable() {
+        use crate::fonts::compute_font_encoding;
+
+        let (doc, page_id) = doc_with_unmappable_type0_font(b"");
+
+        let encoding = compute_font_encoding(&doc, page_id, "F1")
+            .expect("A Type0 font without a ToUnicode CMap should not be an error");
+
+        assert!(
+            matches!(encoding, FontEncoding::Unmappable),
+            "Expected Unmappable, got {encoding:?}"
+        );
+    }
+
+    #[test]
+    fn test_unmappable_font_text_is_skipped_and_counted() {
+        // One TJ block with a hex string (8 hex chars = 2 CIDs), and one with a literal string
+        // (4 bytes = 2 two-byte CIDs).
+        let (doc, page_id) =
+            doc_with_unmappable_type0_font(b"BT /F1 12 Tf [<ABCD1234>]TJ [(ABCD)]TJ ET");
+
+        let mut parser = PdfParser::default();
+        let result = parser
+            .parse_content(&doc, page_id, 0, false)
+            .expect("Parsing text in an unmappable font should not be an error");
+
+        test_eq!(result.skipped_chars, 4);
+        assert!(
+            result.content.trim().is_empty(),
+            "Expected no extracted content, got {:?}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn test_process_tj_tokens_counts_skipped_cids() {
+        let (doc, page_id) = doc_with_unmappable_type0_font(b"");
+
+        let mut parser = PdfParser {
+            cur_font_id: "F1".to_string(),
+            cur_font: "FakeFont".to_string(),
+            ..PdfParser::default()
+        };
+
+        // 8 hex chars = 2 CIDs; 4 literal bytes = 2 CIDs.
+        let tokens = vec![Token::Hex(b"ABCD1234"), Token::Literal(b"ABCD")];
+        let (text, skipped) = parser.process_tj_tokens(&tokens, &doc, page_id).unwrap();
+
+        test_eq!(skipped, 4);
+        assert!(text.trim().is_empty(), "Expected no text, got {text:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes: ZOT-190