### PR TITLE
feat(rag): add system prompt support

### DIFF
--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -254,7 +254,9 @@ fn parse_bfchar_block(
         let code_units: Vec<u16> = parts[1]
             .trim_matches(|c| c == '<' || c == '>')
             .as_bytes()
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|chunk| u16::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16))
             .collect::<Result<_, _>>()
             .map_err(|_| PdfError::InvalidUtf8)?;
@@ -346,7 +348,9 @@ fn parse_bfrange_block(
         let mut code_units: Vec<u16> = parts[2]
             .trim_matches(|c| c == '<' || c == '>')
             .as_bytes()
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|chunk| u16::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16))
             .collect::<Result<_, _>>()
             .map_err(|_| PdfError::InvalidUtf8)?;

--- a/zqa-pdftools/src/tokenizer.rs
+++ b/zqa-pdftools/src/tokenizer.rs
@@ -185,7 +185,7 @@ pub(crate) fn tokenize(content: &[u8]) -> Vec<Token<'_>> {
                                         && &w[1..3] == b"EI"
                                         && (is_whitespace(w[3]) || is_delimiter(w[3]))
                                 })
-                                .map_or(len.saturating_sub(i + 1), |idx| idx);
+                                .unwrap_or(len.saturating_sub(i + 1));
                             i = img_end + i + 1;
                         }
                         _ => {}

--- a/zqa-rag/src/llm/anthropic.rs
+++ b/zqa-rag/src/llm/anthropic.rs
@@ -100,6 +100,9 @@ pub(crate) struct AnthropicRequest<'a> {
     pub(crate) max_tokens: u32,
     /// The conversation history and current message
     pub(crate) messages: &'a [AnthropicChatHistoryItem],
+    /// Instructions that guide the model for the entire request
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) system: Option<&'a str>,
     /// Thinking/reasoning configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) thinking: Option<AnthropicThinkingConfig>,
@@ -331,6 +334,7 @@ impl<T: HttpClient> AgenticClient for AnthropicClient<T> {
     async fn send_once(
         &self,
         history: &[Self::HistoryItem],
+        system_prompt: Option<&str>,
         tools: Option<&[SerializedTool<'_>]>,
         reasoning: Option<&ReasoningConfig>,
         max_tokens: Option<u32>,
@@ -354,6 +358,7 @@ impl<T: HttpClient> AgenticClient for AnthropicClient<T> {
             model: &model,
             max_tokens: max_tokens.unwrap_or(config_max_tokens),
             messages: history,
+            system: system_prompt,
             thinking: reasoning.map(Into::into),
             tools,
         };
@@ -395,9 +400,7 @@ mod tests {
         AnthropicToolUseResponseContent, AnthropicUsageStats,
     };
     use crate::config::AnthropicConfig;
-    use crate::http_client::{
-        MockHttpClient, RecordingSequentialMockHttpClient, ReqwestClient, SequentialMockHttpClient,
-    };
+    use crate::http_client::{MockHttpClient, RecordingSequentialMockHttpClient, ReqwestClient};
     use crate::llm::anthropic::{
         AnthropicOutputTokensDetails, AnthropicTextResponseContent, DEFAULT_CLAUDE_MODEL,
     };
@@ -485,6 +488,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Hello!".to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -535,6 +539,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Hello!".to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -571,6 +576,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "This is a test. Call the `mock_tool`, passing in a `name`, and ensure it returns a greeting".into(),
+            system_prompt: None,
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: None,
@@ -649,6 +655,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Test".into(),
+            system_prompt: Some("Follow the system instructions.".into()),
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: Some(Arc::new(move |_| {
@@ -660,8 +667,10 @@ mod tests {
             tool_iteration_limit: None,
         };
 
+        let http_client =
+            RecordingSequentialMockHttpClient::new([tool_call_response, text_response]);
         let mock_client = AnthropicClient {
-            client: SequentialMockHttpClient::new([tool_call_response, text_response]),
+            client: http_client.clone(),
             config: None,
         };
         let res = mock_client.send_message(&request).await;
@@ -671,6 +680,9 @@ mod tests {
         let texts = text_segments.lock().unwrap();
         test_eq!(texts.len(), 1);
         test_eq!(texts[0].as_str(), "Done!");
+        for request in http_client.requests() {
+            test_eq!(request["system"], "Follow the system instructions.");
+        }
     }
 
     #[test]
@@ -753,6 +765,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(2048),
             message: "Test".into(),
+            system_prompt: None,
             reasoning: Some(ReasoningConfig {
                 max_tokens: Some(1024),
                 effort: None,

--- a/zqa-rag/src/llm/base.rs
+++ b/zqa-rag/src/llm/base.rs
@@ -134,6 +134,8 @@ pub struct ChatRequest<'a> {
     pub max_tokens: Option<u32>,
     /// The message to send
     pub message: String,
+    /// Instructions that guide the model for the entire request
+    pub system_prompt: Option<String>,
     /// Reasoning config. Optional.
     pub reasoning: Option<ReasoningConfig>,
     /// The tools to use
@@ -220,6 +222,7 @@ where
     async fn send_once(
         &self,
         history: &[Self::HistoryItem],
+        system_prompt: Option<&str>,
         tools: Option<&[SerializedTool<'_>]>,
         reasoning: Option<&ReasoningConfig>,
         max_tokens: Option<u32>,
@@ -266,6 +269,7 @@ where
             let turn = self
                 .send_once(
                     &history,
+                    request.system_prompt.as_deref(),
                     tools_passed,
                     request.reasoning.as_ref(),
                     request.max_tokens,
@@ -350,6 +354,7 @@ mod tests {
 
     struct TestClient {
         turns: Mutex<VecDeque<ProviderTurn<TestHistoryItem>>>,
+        system_prompts_seen: Arc<Mutex<Vec<Option<String>>>>,
         tools_seen: Arc<Mutex<Vec<Option<usize>>>>,
     }
 
@@ -364,10 +369,15 @@ mod tests {
         async fn send_once(
             &self,
             _: &[Self::HistoryItem],
+            system_prompt: Option<&str>,
             tools: Option<&[SerializedTool<'_>]>,
             _: Option<&ReasoningConfig>,
             _: Option<u32>,
         ) -> Result<ProviderTurn<Self::HistoryItem>, LLMError> {
+            self.system_prompts_seen
+                .lock()
+                .unwrap()
+                .push(system_prompt.map(ToOwned::to_owned));
             self.tools_seen.lock().unwrap().push(tools.map(<[_]>::len));
             Ok(self.turns.lock().unwrap().pop_front().unwrap())
         }
@@ -409,6 +419,7 @@ mod tests {
                     },
                 },
             ])),
+            system_prompts_seen: Arc::new(Mutex::new(Vec::new())),
             tools_seen: Arc::clone(&tools_seen),
         };
         let call_count = Arc::new(Mutex::new(0));
@@ -416,6 +427,7 @@ mod tests {
             call_count: Arc::clone(&call_count),
         };
         let request = ChatRequest {
+            system_prompt: Some("Follow the system instructions.".into()),
             tools: Some(&[Box::new(tool)]),
             tool_iteration_limit: Some(2),
             ..ChatRequest::default()
@@ -424,6 +436,13 @@ mod tests {
         let response = client.send_message(&request).await.unwrap();
 
         assert_eq!(*tools_seen.lock().unwrap(), vec![Some(1), None]);
+        assert_eq!(
+            *client.system_prompts_seen.lock().unwrap(),
+            vec![
+                Some("Follow the system instructions.".into()),
+                Some("Follow the system instructions.".into())
+            ]
+        );
         assert_eq!(*call_count.lock().unwrap(), 1);
         assert_eq!(response.usage.input_tokens, 30);
         assert_eq!(response.usage.input_cache_written, 6);
@@ -445,6 +464,7 @@ mod tests {
                 contents: vec![ChatHistoryContent::Text("done".into())],
                 usage: ModelUsage::default(),
             }])),
+            system_prompts_seen: Arc::new(Mutex::new(Vec::new())),
             tools_seen: Arc::clone(&tools_seen),
         };
         let tool = MockTool {

--- a/zqa-rag/src/llm/base.rs
+++ b/zqa-rag/src/llm/base.rs
@@ -339,6 +339,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::future::{Future, ready};
     use std::sync::{Arc, Mutex};
 
     use super::*;
@@ -366,20 +367,20 @@ mod tests {
             Vec::new()
         }
 
-        async fn send_once(
+        fn send_once(
             &self,
             _: &[Self::HistoryItem],
             system_prompt: Option<&str>,
             tools: Option<&[SerializedTool<'_>]>,
             _: Option<&ReasoningConfig>,
             _: Option<u32>,
-        ) -> Result<ProviderTurn<Self::HistoryItem>, LLMError> {
+        ) -> impl Future<Output = Result<ProviderTurn<Self::HistoryItem>, LLMError>> {
             self.system_prompts_seen
                 .lock()
                 .unwrap()
                 .push(system_prompt.map(ToOwned::to_owned));
             self.tools_seen.lock().unwrap().push(tools.map(<[_]>::len));
-            Ok(self.turns.lock().unwrap().pop_front().unwrap())
+            ready(Ok(self.turns.lock().unwrap().pop_front().unwrap()))
         }
     }
 

--- a/zqa-rag/src/llm/gemini.rs
+++ b/zqa-rag/src/llm/gemini.rs
@@ -82,6 +82,12 @@ pub(crate) struct GeminiContent {
     parts: Vec<GeminiPart>,
 }
 
+/// Instructions that guide Gemini for the entire request.
+#[derive(Serialize, Clone)]
+struct GeminiSystemInstruction {
+    parts: Vec<GeminiPart>,
+}
+
 impl From<ChatHistoryItem> for Vec<GeminiContent> {
     fn from(value: ChatHistoryItem) -> Self {
         vec![value.into()]
@@ -180,6 +186,8 @@ struct GeminiToolDeclaration<'a> {
 #[serde(rename_all = "camelCase")]
 struct GeminiRequestBody<'a> {
     contents: &'a [GeminiContent],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_instruction: Option<GeminiSystemInstruction>,
     #[serde(skip_serializing_if = "Option::is_none")]
     generation_config: Option<GeminiGenerationConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -324,6 +332,7 @@ impl<T: HttpClient> AgenticClient for GeminiClient<T> {
     async fn send_once(
         &self,
         history: &[Self::HistoryItem],
+        system_prompt: Option<&str>,
         tools: Option<&[SerializedTool<'_>]>,
         reasoning: Option<&ReasoningConfig>,
         max_tokens: Option<u32>,
@@ -344,6 +353,12 @@ impl<T: HttpClient> AgenticClient for GeminiClient<T> {
         // Create the initial request borrowing
         let request = GeminiRequestBody {
             contents: history,
+            system_instruction: system_prompt.map(|text| GeminiSystemInstruction {
+                parts: vec![GeminiPart::Text {
+                    text: text.to_owned(),
+                    thought_signature: None,
+                }],
+            }),
             generation_config: generation_config.clone(),
             tools: tools.as_ref(),
         };
@@ -386,7 +401,7 @@ mod tests {
     use super::*;
     use crate::clients::gemini::GeminiClient;
     use crate::constants::DEFAULT_GEMINI_EMBEDDING_DIM;
-    use crate::http_client::{MockHttpClient, ReqwestClient, SequentialMockHttpClient};
+    use crate::http_client::{MockHttpClient, RecordingSequentialMockHttpClient, ReqwestClient};
     use crate::llm::base::{AgenticClient, ChatHistoryItem, ChatRequest, ContentType};
     use crate::llm::tools::test_utils::MockTool;
 
@@ -429,6 +444,7 @@ mod tests {
                 content: vec![ChatHistoryContent::Text("Prior".into())],
             }],
             max_tokens: Some(256),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -519,6 +535,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Hello!".to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -543,6 +560,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "This is a test. Call the `mock_tool`, passing in a `name`, and ensure it returns a greeting".into(),
+            system_prompt: None,
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: None,
@@ -620,6 +638,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Test".into(),
+            system_prompt: Some("Follow the system instructions.".into()),
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: Some(Arc::new(move |_| {
@@ -631,8 +650,10 @@ mod tests {
             tool_iteration_limit: None,
         };
 
+        let http_client =
+            RecordingSequentialMockHttpClient::new([tool_call_response, text_response]);
         let mock_client = GeminiClient {
-            client: SequentialMockHttpClient::new([tool_call_response, text_response]),
+            client: http_client.clone(),
             config: None,
         };
         let res = mock_client.send_message(&request).await;
@@ -642,6 +663,12 @@ mod tests {
         let texts = text_segments.lock().unwrap();
         test_eq!(texts.len(), 1);
         test_eq!(texts[0].as_str(), "Done!");
+        for request in http_client.requests() {
+            test_eq!(
+                request["systemInstruction"]["parts"][0]["text"],
+                "Follow the system instructions."
+            );
+        }
     }
 
     #[tokio::test]

--- a/zqa-rag/src/llm/ollama.rs
+++ b/zqa-rag/src/llm/ollama.rs
@@ -45,6 +45,7 @@ impl<T: HttpClient> AgenticClient for OllamaClient<T> {
     async fn send_once(
         &self,
         history: &[Self::HistoryItem],
+        system_prompt: Option<&str>,
         tools: Option<&[SerializedTool<'_>]>,
         reasoning: Option<&ReasoningConfig>,
         max_tokens: Option<u32>,
@@ -68,6 +69,7 @@ impl<T: HttpClient> AgenticClient for OllamaClient<T> {
             model: &model,
             max_tokens: max_tokens.unwrap_or(config_max_tokens),
             messages: history,
+            system: system_prompt,
             thinking: reasoning.map(Into::into),
             tools,
         };
@@ -101,7 +103,7 @@ mod tests {
 
     use super::*;
     use crate::clients::ollama::OllamaClient;
-    use crate::http_client::{ReqwestClient, SequentialMockHttpClient};
+    use crate::http_client::{RecordingSequentialMockHttpClient, ReqwestClient};
     use crate::llm::anthropic::{
         AnthropicOutputTokensDetails, AnthropicResponseContent, AnthropicTextResponseContent,
         AnthropicToolUseResponseContent, AnthropicUsageStats,
@@ -125,6 +127,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Hello!".to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -157,6 +160,7 @@ mod tests {
             max_tokens: Some(1024),
             message: "Call the mock_tool function with the name parameter set to 'Alice'"
                 .to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: None,
@@ -236,6 +240,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Test".into(),
+            system_prompt: Some("Follow the system instructions.".into()),
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: Some(Arc::new(move |_| {
@@ -247,8 +252,10 @@ mod tests {
             tool_iteration_limit: None,
         };
 
+        let http_client =
+            RecordingSequentialMockHttpClient::new([tool_call_response, text_response]);
         let mock_client = OllamaClient {
-            client: SequentialMockHttpClient::new([tool_call_response, text_response]),
+            client: http_client.clone(),
             config: None,
         };
         let res = mock_client.send_message(&request).await;
@@ -261,6 +268,9 @@ mod tests {
         let texts = text_segments.lock().unwrap();
         test_eq!(texts.len(), 1);
         test_eq!(texts[0].as_str(), "Done!");
+        for request in http_client.requests() {
+            test_eq!(request["system"], "Follow the system instructions.");
+        }
     }
 
     #[tokio::test]

--- a/zqa-rag/src/llm/openai.rs
+++ b/zqa-rag/src/llm/openai.rs
@@ -210,6 +210,10 @@ pub(crate) struct OpenAIRequest<'a> {
     /// The flattened chat history and current message.
     input: &'a [OpenAIRequestInput],
 
+    /// Instructions that guide the model for the entire request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instructions: Option<&'a str>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning: Option<OpenAIReasoning>,
 
@@ -443,6 +447,7 @@ impl<T: HttpClient> AgenticClient for OpenAIClient<T> {
     async fn send_once(
         &self,
         history: &[Self::HistoryItem],
+        system_prompt: Option<&str>,
         tools: Option<&[SerializedTool<'_>]>,
         reasoning: Option<&ReasoningConfig>,
         max_tokens: Option<u32>,
@@ -461,6 +466,7 @@ impl<T: HttpClient> AgenticClient for OpenAIClient<T> {
         let request_body = OpenAIRequest {
             model: &model,
             input: history,
+            instructions: system_prompt,
             reasoning: reasoning.map(Into::into),
             max_output_tokens: max_tokens,
             tools: wrapped_tools.as_deref(),
@@ -547,8 +553,8 @@ mod tests {
     use zqa_macros::{test_eq, test_ok};
 
     use super::{
-        OpenAIClient, OpenAIContent, OpenAIOutput, OpenAIOutputReasoningSummary, OpenAIResponse,
-        OpenAIUsage,
+        OpenAIClient, OpenAIContent, OpenAIOutput, OpenAIOutputReasoningSummary, OpenAIRequest,
+        OpenAIResponse, OpenAIUsage,
     };
     use crate::config::OpenAIConfig;
     use crate::constants::DEFAULT_OPENAI_EMBEDDING_DIM;
@@ -569,6 +575,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Hello!".to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -624,6 +631,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Hello!".to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -682,6 +690,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "This is a test. Call the `mock_tool`, passing in a `name`, and ensure it returns a greeting".into(),
+            system_prompt: None,
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: None,
@@ -754,6 +763,26 @@ mod tests {
         assert_eq!(request["tools"][0]["type"].as_str(), Some("function"));
     }
 
+    #[test]
+    fn request_serializes_system_prompt_as_instructions() {
+        let input = Vec::new();
+        let request = OpenAIRequest {
+            model: "gpt-5",
+            input: &input,
+            instructions: Some("Follow the system instructions."),
+            reasoning: None,
+            max_output_tokens: None,
+            tools: None,
+        };
+
+        let serialized = serde_json::to_value(request).unwrap();
+
+        test_eq!(
+            serialized["instructions"],
+            "Follow the system instructions."
+        );
+    }
+
     fn input_item<'a>(input: &'a [serde_json::Value], item_type: &str) -> &'a serde_json::Value {
         input
             .iter()
@@ -797,7 +826,6 @@ mod tests {
         let tool_call_count = Arc::new(Mutex::new(0_usize));
         let text_segments = Arc::new(Mutex::new(Vec::new()));
         let request = ChatRequest {
-            chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Test".into(),
             reasoning: Some(ReasoningConfig {
@@ -814,7 +842,7 @@ mod tests {
                 let text_segments = Arc::clone(&text_segments);
                 move |text| text_segments.lock().unwrap().push(text.to_string())
             })),
-            tool_iteration_limit: None,
+            ..ChatRequest::default()
         };
         let http_client =
             RecordingSequentialMockHttpClient::new([tool_call_response, text_response]);

--- a/zqa-rag/src/llm/openrouter.rs
+++ b/zqa-rag/src/llm/openrouter.rs
@@ -1,6 +1,7 @@
 //! Functions, structs, and trait implementations for interacting with the OpenRouter API. This
 //! module includes support for text generation only.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::env;
 
@@ -361,20 +362,25 @@ impl<T: HttpClient> AgenticClient for OpenRouterClient<T> {
                 })
                 .collect::<Vec<_>>()
         });
-        let system_message = system_prompt.map(|content| OpenRouterMessage {
-            role: OpenRouterMessageRole::System,
-            content: Some(content.to_owned()),
-            tool_calls: None,
-            tool_call_id: None,
-        });
-        let messages = system_message
-            .iter()
-            .chain(history)
-            .cloned()
-            .collect::<Vec<_>>();
+        let messages = match system_prompt {
+            Some(content) => {
+                let system_message = OpenRouterMessage {
+                    role: OpenRouterMessageRole::System,
+                    content: Some(content.to_owned()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                };
+                Cow::Owned(
+                    std::iter::once(system_message)
+                        .chain(history.iter().cloned())
+                        .collect(),
+                )
+            }
+            None => Cow::Borrowed(history),
+        };
         let request_body = OpenRouterRequest {
             model: &model,
-            messages: &messages,
+            messages: messages.as_ref(),
             reasoning: reasoning.map(Into::into),
             tools: wrapped_tools,
             max_tokens: max_tokens.unwrap_or(config_max_tokens),

--- a/zqa-rag/src/llm/openrouter.rs
+++ b/zqa-rag/src/llm/openrouter.rs
@@ -21,10 +21,30 @@ use crate::pricing::ModelUsage;
 
 const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4.5";
 
+/// Roles accepted by OpenRouter's chat completions API.
+#[derive(Copy, Clone, Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum OpenRouterMessageRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+impl From<MessageRole> for OpenRouterMessageRole {
+    fn from(role: MessageRole) -> Self {
+        match role {
+            MessageRole::User => Self::User,
+            MessageRole::Assistant => Self::Assistant,
+            MessageRole::Tool => Self::Tool,
+        }
+    }
+}
+
 /// OpenRouter-specific message format
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct OpenRouterMessage {
-    role: MessageRole,
+    role: OpenRouterMessageRole,
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -113,7 +133,7 @@ fn convert_to_openrouter_messages(item: &ChatHistoryItem) -> Vec<OpenRouterMessa
             ChatHistoryContent::ToolCallResponse(res) => {
                 // Tool responses in OpenRouter are sent as a separate message with role "tool"
                 messages.push(OpenRouterMessage {
-                    role: MessageRole::Tool,
+                    role: OpenRouterMessageRole::Tool,
                     content: Some(serde_json::to_string(&res.result).unwrap_or_default()),
                     tool_calls: None,
                     tool_call_id: Some(res.id.clone()),
@@ -127,7 +147,7 @@ fn convert_to_openrouter_messages(item: &ChatHistoryItem) -> Vec<OpenRouterMessa
         messages.insert(
             0,
             OpenRouterMessage {
-                role: item.role,
+                role: item.role.into(),
                 content: if content_text.is_empty() {
                     None
                 } else {
@@ -300,7 +320,7 @@ impl<T: HttpClient> AgenticClient for OpenRouterClient<T> {
             .collect();
 
         messages.push(OpenRouterMessage {
-            role: MessageRole::User,
+            role: OpenRouterMessageRole::User,
             content: Some(request.message.clone()),
             tool_calls: None,
             tool_call_id: None,
@@ -312,6 +332,7 @@ impl<T: HttpClient> AgenticClient for OpenRouterClient<T> {
     async fn send_once(
         &self,
         history: &[Self::HistoryItem],
+        system_prompt: Option<&str>,
         tools: Option<&[SerializedTool<'_>]>,
         reasoning: Option<&ReasoningConfig>,
         max_tokens: Option<u32>,
@@ -340,9 +361,20 @@ impl<T: HttpClient> AgenticClient for OpenRouterClient<T> {
                 })
                 .collect::<Vec<_>>()
         });
+        let system_message = system_prompt.map(|content| OpenRouterMessage {
+            role: OpenRouterMessageRole::System,
+            content: Some(content.to_owned()),
+            tool_calls: None,
+            tool_call_id: None,
+        });
+        let messages = system_message
+            .iter()
+            .chain(history)
+            .cloned()
+            .collect::<Vec<_>>();
         let request_body = OpenRouterRequest {
             model: &model,
-            messages: history,
+            messages: &messages,
             reasoning: reasoning.map(Into::into),
             tools: wrapped_tools,
             max_tokens: max_tokens.unwrap_or(config_max_tokens),
@@ -369,7 +401,7 @@ impl<T: HttpClient> AgenticClient for OpenRouterClient<T> {
         Ok(ProviderTurn {
             contents,
             native_items: vec![OpenRouterMessage {
-                role: choice.message.role,
+                role: choice.message.role.into(),
                 content: choice.message.content,
                 tool_calls: choice.message.tool_calls,
                 tool_call_id: None,
@@ -392,6 +424,21 @@ mod tests {
     use crate::llm::base::{AgenticClient, ChatRequest, ContentType, ToolCallResponse};
     use crate::llm::tools::test_utils::MockTool;
 
+    #[test]
+    fn system_message_serializes_with_system_role() {
+        let message = OpenRouterMessage {
+            role: OpenRouterMessageRole::System,
+            content: Some("Follow the system instructions.".into()),
+            tool_calls: None,
+            tool_call_id: None,
+        };
+
+        let serialized = serde_json::to_value(message).unwrap();
+
+        test_eq!(serialized["role"], "system");
+        test_eq!(serialized["content"], "Follow the system instructions.");
+    }
+
     #[tokio::test]
     async fn test_request_works() {
         dotenv().ok();
@@ -401,6 +448,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Hello!".to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -456,6 +504,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Hello!".to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: None,
             on_tool_call: None,
@@ -521,6 +570,7 @@ mod tests {
             max_tokens: Some(1024),
             message: "Call the mock_tool function with the name parameter set to 'Alice'"
                 .to_owned(),
+            system_prompt: None,
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: None,
@@ -612,6 +662,7 @@ mod tests {
             chat_history: Vec::new(),
             max_tokens: Some(1024),
             message: "Test".into(),
+            system_prompt: None,
             reasoning: None,
             tools: Some(&[Box::new(tool)]),
             on_tool_call: Some(Arc::new(move |_| {

--- a/zqa/src/cli/handlers/batch.rs
+++ b/zqa/src/cli/handlers/batch.rs
@@ -997,6 +997,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::future::{Future, ready};
     use std::io::Cursor;
 
     use chrono::{Duration, Utc};
@@ -1119,26 +1120,29 @@ mod tests {
     }
 
     impl BatchAPIProvider for MockBatchProvider {
-        async fn submit_batch(
+        fn submit_batch(
             &self,
             _request: BatchEmbeddingRequest,
-        ) -> Result<BatchSubmission, LLMError> {
-            Ok(make_submission("mock-batch"))
+        ) -> impl Future<Output = Result<BatchSubmission, LLMError>> {
+            ready(Ok(make_submission("mock-batch")))
         }
 
-        async fn get_batch_status(&self, _batch_id: &str) -> Result<BatchJobState, LLMError> {
-            Ok(BatchJobState::Completed)
-        }
-
-        async fn get_batch_results(
+        fn get_batch_status(
             &self,
             _batch_id: &str,
-        ) -> Result<BatchEmbeddingResults, LLMError> {
-            Ok(self.results.clone())
+        ) -> impl Future<Output = Result<BatchJobState, LLMError>> {
+            ready(Ok(BatchJobState::Completed))
         }
 
-        async fn cancel_batch(&self, _batch_id: &str) -> Result<(), LLMError> {
-            Ok(())
+        fn get_batch_results(
+            &self,
+            _batch_id: &str,
+        ) -> impl Future<Output = Result<BatchEmbeddingResults, LLMError>> {
+            ready(Ok(self.results.clone()))
+        }
+
+        fn cancel_batch(&self, _batch_id: &str) -> impl Future<Output = Result<(), LLMError>> {
+            ready(Ok(()))
         }
     }
 

--- a/zqa/src/cli/handlers/query.rs
+++ b/zqa/src/cli/handlers/query.rs
@@ -17,7 +17,9 @@ use crate::cli::errors::CLIError;
 use crate::cli::handlers::documents::{
     get_document_mentions, get_user_document_tools, import_document,
 };
-use crate::cli::prompts::{get_summarize_prompt, get_title_prompt};
+use crate::cli::prompts::{
+    get_summarize_prompt, get_summarize_system_prompt, get_title_prompt, get_title_system_prompt,
+};
 use crate::common::Context;
 use crate::state::UsageMetadata;
 use crate::store::common::ZoteroStore;
@@ -181,6 +183,7 @@ where
                 chat_history: Vec::new(),
                 max_tokens: Some(20),
                 message: prompt,
+                system_prompt: Some(get_title_system_prompt().to_owned()),
                 reasoning: None,
                 tools: None,
                 on_tool_call: None,
@@ -263,6 +266,7 @@ where
             chat_history: history.clone(),
             max_tokens: None,
             message: get_summarize_prompt(&query),
+            system_prompt: Some(get_summarize_system_prompt()),
             reasoning: ctx.config.get_reasoning_config(),
             tools: Some(&tools),
             on_tool_call: None,

--- a/zqa/src/cli/prompts.rs
+++ b/zqa/src/cli/prompts.rs
@@ -2,6 +2,44 @@ use crate::tools::retrieval::RETRIEVAL_TOOL_NAME;
 use crate::tools::summarization::SUMMARIZATION_TOOL_NAME;
 use crate::utils::library::ZoteroItemMetadata;
 
+/// Get the system prompt used to extract relevant passages from a paper.
+///
+/// # Returns
+///
+/// Instructions for extracting and formatting relevant passages.
+#[must_use]
+pub fn get_extraction_system_prompt() -> &'static str {
+    "Given a question from a user and the full text from a research paper, extract the relevant
+parts that are suitable for answering the question. Wrap each relevant excerpt from the paper in
+<excerpt></excerpt> tags. Here are some guidelines:
+
+1. It is best to quote excerpts verbatim. You may correct spelling errors, but do not modify other
+parts of the text.
+2. Some parts of the text, especially equations, may appear as hard to understand text. This is a
+currently-known limitation: for now, repeat these verbatim. You may add a best-guess of what the
+equation was supposed to be, in LaTeX form and wrapped in double-dollar signs ($$...$$), inside
+parentheses after such malformed text. Inside the parentheses, indicate that this is a \"possible fix\".
+Aside from this, do not modify the source text.
+3. You are encouraged to also cite excerpts from the paper that cite other papers, *if these excerpts
+are relevant*. In such cases, if the citation uses numbers, change the numbering to be an author-year
+format, preferably in the APA style. Write all your references at the end of your response, after a
+\"References:\" header. If the user specifically requests a different citation style such as
+MLA, you should use that instead.
+4. Some text from the paper's Appendix or Supplementary Material may be in this text. Do not use
+excerpts from this material.
+
+Format your response in exactly the below format:
+
+<title>Paper title here</title>
+<authors>Author list</authors>
+<reference>An APA-style citation to the current paper</reference>
+<excerpt>An excerpt here</excerpt>
+<excerpt>Another excerpt here</excerpt>
+
+Note that if the user requests references to be in a different format (e.g., MLA, Chicago), you should use that
+reference format instead of APA."
+}
+
 /// Get the "extraction" prompt, which extracts the relevant parts of a retrieved paper. This is
 /// the first step of the question-answering process.
 ///
@@ -21,26 +59,8 @@ pub fn get_extraction_prompt(query: &str, pdf_text: &str, metadata: &ZoteroItemM
     );
     let title = &metadata.title;
 
-    format!("Given a question from a user and the full text from a research paper, extract the relevant
-parts that are suitable for answering the question. Wrap each relevant excerpt from the paper in
-<excerpt></excerpt> tags. Here are some guidelines:
-
-1. It is best to quote excerpts verbatim. You may correct spelling errors, but do not modify other
-parts of the text.
-2. Some parts of the text, especially equations, may appear as hard to understand text. This is a
-currently-known limitation: for now, repeat these verbatim. You may add a best-guess of what the
-equation was supposed to be, in LaTeX form and wrapped in double-dollar signs ($$...$$), inside
-parentheses after such malformed text. Inside the parentheses, indicate that this is a \"possible fix\".
-Aside from this, do not modify the source text.
-3. You are encouraged to also cite excerpts from the paper that cite other papers, *if these excerpts
-are relevant*. In such cases, if the citation uses numbers, change the numbering to be an author-year
-format, preferably in the APA style. Write all your references at the end of your response, after a
-\"References:\" header. If the user specifically requests a different citation style such as
-MLA, you should use that instead.
-4. Some text from the paper's Appendix or Supplementary Material may be in this text. Do not use
-excerpts from this material.
-
-Here is the user query: <user_query>{query}</user_query>.
+    format!(
+        "Here is the user query: <user_query>{query}</user_query>.
 
 Below is some information about the paper:
 <metadata>
@@ -52,18 +72,20 @@ Below is the full text of the paper:
 
 <pdf_text>
 {pdf_text}
-</pdf_text>
+</pdf_text>"
+    )
+}
 
-Format your response in exactly the below format:
-
-<title>Paper title here</title>
-<authors>Author list</authors>
-<reference>An APA-style citation to the current paper</reference>
-<excerpt>An excerpt here</excerpt>
-<excerpt>Another excerpt here</excerpt>
-
-Note that if the user requests references to be in a different format (e.g., MLA, Chicago), you should use that
-reference format instead of APA.")
+/// Get the system prompt used to generate a conversation title.
+///
+/// # Returns
+///
+/// Instructions for generating a short conversation title.
+#[must_use]
+pub fn get_title_system_prompt() -> &'static str {
+    "You are given a user query to an AI assistant that grounds its response in the user's
+Zotero library. Generate a short, descriptive title for this conversation in 10 words or fewer.
+The title should capture the main topic. Respond with only the title text, no quotes or punctuation."
 }
 
 /// Get the "title" prompt, which generates a short title for a conversation based on the user
@@ -79,28 +101,19 @@ reference format instead of APA.")
 #[must_use]
 pub fn get_title_prompt(query: &str) -> String {
     format!(
-        "You are given a user query to an AI assistant that grounds its response in the user's
-Zotero library. Generate a short, descriptive title for this conversation in 10 words or fewer. \
-The title should capture the main topic. Respond with only the title text, no quotes or punctuation.
-
-<user_query>
+        "<user_query>
 {query}
-</user_query>"
+    </user_query>"
     )
 }
 
-/// Get the "summarization" prompt, which directs the LLM to retrieve evidence from the user's
-/// Zotero library before generating a researched answer to the user query.
-///
-/// # Arguments
-///
-/// * `query` - The user query to answer
+/// Get the system prompt used to answer questions from the user's Zotero library.
 ///
 /// # Returns
 ///
-/// * `prompt` - The prompt for answering the user query
+/// Instructions for retrieving evidence and writing a grounded response.
 #[must_use]
-pub fn get_summarize_prompt(query: &str) -> String {
+pub fn get_summarize_system_prompt() -> String {
     format!(
         "You answer questions grounded in the user's Zotero library. You have tools to search the library and
 extract relevant passages; your answer MUST be grounded in what they return. No excerpts are provided with
@@ -135,33 +148,48 @@ straightforward answer (based on the search results). In this case, it is usuall
 directly.
 8. Not all search results and excerpts may be relevant. You do *not* need to use *all* the excerpts and search results.
 Instead, use excerpts and search results that have relevant information to the user's query. If you are unsure, err
-on the side of *inclusion*. It is better to erroneously include a paper than to falsely ignore one.
+on the side of *inclusion*. It is better to erroneously include a paper than to falsely ignore one."
+    )
+}
 
-Here is the user query: <user_query>{query}</user_query>.")
+/// Get the "summarization" prompt, which directs the LLM to retrieve evidence from the user's
+/// Zotero library before generating a researched answer to the user query.
+///
+/// # Arguments
+///
+/// * `query` - The user query to answer
+///
+/// # Returns
+///
+/// * `prompt` - The prompt for answering the user query
+#[must_use]
+pub fn get_summarize_prompt(query: &str) -> String {
+    format!("Here is the user query: <user_query>{query}</user_query>.")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::get_summarize_prompt;
+    use super::{get_summarize_prompt, get_summarize_system_prompt};
     use crate::tools::retrieval::RETRIEVAL_TOOL_NAME;
     use crate::tools::summarization::SUMMARIZATION_TOOL_NAME;
 
     #[test]
     fn summarize_prompt_requires_retrieval_before_answering() {
+        let system_prompt = get_summarize_system_prompt();
         let prompt = get_summarize_prompt("How does retrieval-augmented generation work?");
         let retrieval_instruction = format!("Start by calling `{RETRIEVAL_TOOL_NAME}`");
         let summarization_instruction = format!("Then call `{SUMMARIZATION_TOOL_NAME}`");
-        let retrieval_position = prompt
+        let retrieval_position = system_prompt
             .find(&retrieval_instruction)
             .expect("prompt should instruct retrieval first");
-        let summarization_position = prompt
+        let summarization_position = system_prompt
             .find(&summarization_instruction)
             .expect("prompt should instruct passage extraction second");
 
-        assert!(prompt.contains("MUST be grounded in what they return."));
-        assert!(prompt.contains("No excerpts are provided"));
+        assert!(system_prompt.contains("MUST be grounded in what they return."));
+        assert!(system_prompt.contains("No excerpts are provided"));
         assert!(retrieval_position < summarization_position);
-        assert!(prompt.contains("do not keep searching."));
+        assert!(system_prompt.contains("do not keep searching."));
         assert!(
             prompt
                 .contains("<user_query>How does retrieval-augmented generation work?</user_query>")

--- a/zqa/src/cli/prompts.rs
+++ b/zqa/src/cli/prompts.rs
@@ -103,7 +103,7 @@ pub fn get_title_prompt(query: &str) -> String {
     format!(
         "<user_query>
 {query}
-    </user_query>"
+</user_query>"
     )
 }
 
@@ -169,7 +169,7 @@ pub fn get_summarize_prompt(query: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_summarize_prompt, get_summarize_system_prompt};
+    use super::{get_summarize_prompt, get_summarize_system_prompt, get_title_prompt};
     use crate::tools::retrieval::RETRIEVAL_TOOL_NAME;
     use crate::tools::summarization::SUMMARIZATION_TOOL_NAME;
 
@@ -193,6 +193,14 @@ mod tests {
         assert!(
             prompt
                 .contains("<user_query>How does retrieval-augmented generation work?</user_query>")
+        );
+    }
+
+    #[test]
+    fn title_prompt_has_symmetric_tags() {
+        assert_eq!(
+            get_title_prompt("How does RAG work?"),
+            "<user_query>\nHow does RAG work?\n</user_query>"
         );
     }
 }

--- a/zqa/src/tools/summarization.rs
+++ b/zqa/src/tools/summarization.rs
@@ -12,7 +12,7 @@ use zqa_rag::llm::factory::LLMClient;
 use zqa_rag::llm::tools::Tool;
 use zqa_rag::pricing::ModelUsage;
 
-use crate::cli::prompts::get_extraction_prompt;
+use crate::cli::prompts::{get_extraction_prompt, get_extraction_system_prompt};
 use crate::store::common::ZoteroStore;
 use crate::tools::retrieval::RETRIEVAL_TOOL_NAME;
 use crate::utils::library::ZoteroItem;
@@ -113,6 +113,7 @@ where
                         chat_history: Vec::new(),
                         max_tokens: None,
                         message: get_extraction_prompt(&query_cloned, &text, &metadata),
+                        system_prompt: Some(get_extraction_system_prompt().to_owned()),
                         reasoning: client.get_reasoning_config(),
                         tools: None, // We ARE the tool :3
                         on_tool_call: None,

--- a/zqa/tests/extraction_prompt.rs
+++ b/zqa/tests/extraction_prompt.rs
@@ -2,7 +2,7 @@ use std::{env, fs};
 
 use dotenv::dotenv;
 use log::LevelFilter;
-use zqa::cli::prompts::get_extraction_prompt;
+use zqa::cli::prompts::{get_extraction_prompt, get_extraction_system_prompt};
 use zqa::common::setup_logger;
 use zqa::config::{AnthropicConfig, GeminiConfig, OpenAIConfig};
 use zqa::utils::library::ZoteroItemMetadata;
@@ -33,6 +33,7 @@ async fn run_extraction_test(client: zqa_rag::llm::factory::LLMClient, provider_
         chat_history: Vec::new(),
         max_tokens: None,
         message: prompt,
+        system_prompt: Some(get_extraction_system_prompt().to_owned()),
         reasoning: None,
         tools: None,
         on_tool_call: None,


### PR DESCRIPTION
## Summary

- add provider-agnostic system prompts to `ChatRequest`
- map system prompts to the native Anthropic, Ollama, OpenAI, Gemini, and OpenRouter request formats
- separate zqa system instructions from per-turn user content for title generation, retrieval, and passage extraction
- verify system prompts are preserved across agentic tool-call rounds

## Rationale

System-level instructions should be represented through each provider's native API rather than embedded in user messages.

## Tests

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p zqa-rag --all-features -- --skip llm::ollama::tests::test_request_works --skip llm::ollama::tests::test_request_with_tool_works`
- `cargo test -p zqa cli::prompts::tests:: --all-features`
- `cargo test -p zqa state::tests::test_get_state_dir --all-features -- --exact`

The two live Ollama tests were skipped as expected. The full `zqa` suite had one environment-sensitive state-directory test fail under concurrent execution; it passed in isolation.