### PR TITLE
fix(pdftools): support ToUnicode for simple fonts

### DIFF
--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -48,7 +48,7 @@ pub(crate) struct FontSizeMarker {
 }
 
 /// A type to convert from bytes in math fonts to LaTeX code
-type ByteTransformFn = fn(u8) -> std::borrow::Cow<'static, str>;
+type ByteTransformFn = fn(u8) -> Option<std::borrow::Cow<'static, str>>;
 
 /// A zero-allocation iterator for octal escape sequences and raw bytes. This is useful for parsing
 /// octal escape codes that are used in math fonts when non-printable characters are used to
@@ -97,7 +97,9 @@ pub(crate) fn font_transform(input: &str, transform: ByteTransformFn) -> String 
         bytes: input.as_bytes(),
         pos: 0,
     }
-    .map(transform)
+    .map(|code| {
+        transform(code).unwrap_or_else(|| std::borrow::Cow::Owned(char::from(code).to_string()))
+    })
     .collect::<String>()
 }
 
@@ -137,13 +139,16 @@ pub(crate) static FONT_TRANSFORMS: LazyLock<HashMap<&'static str, ByteTransformF
 /// The mappings of a ToUnicode CMap. For now, we do not support other kinds of CMaps.
 pub(crate) type CMap = HashMap<String, String>;
 
-/// The type of encoding used by a font. Either `SIMPLE` (human-readable) or `CID_KEYED`
-/// (Unicode/glyph ID-encoded)
+/// The type of encoding used by a font.
 #[derive(Clone, Debug)]
 pub(crate) enum FontEncoding {
-    /// Human-readable, "simple" encoding. Under this encoding, each TJ block has contents that can
-    /// be parsed as plain text.
-    Simple,
+    /// A simple font whose character codes are one byte wide.
+    Simple {
+        /// The character-code-to-Unicode mappings parsed from the optional `ToUnicode` CMap.
+        mappings: Option<CMap>,
+        /// The character code that maps to a space (U+0020), if the CMap defines one.
+        space_code: Option<i64>,
+    },
     /// CID-keyed, or glyph ID-encoded font. For this encoding, the font usually is a subsetted
     /// embedded font (i.e., a CID-keyed subset of a font that's embedded), and we need to check
     /// the `ToUnicode` CMap for that font. It is possible to also use non-ToUnicode CMaps; we do
@@ -476,15 +481,66 @@ pub(crate) fn parse_cmap(
     Ok((mappings, space_cid))
 }
 
-/// Attempt to get the font encoding for a font key on a specific page.
+/// Read and parse a font's `ToUnicode` CMap.
 ///
-/// This function uses heuristics to determine whether a font is likely to be "simple" (i.e.,
-/// can be parsed as plain-text), or needs to be translated via a corresponding CMap.
+/// # Arguments
+///
+/// * `doc` - The PDF document containing the CMap.
+/// * `to_unicode` - The font dictionary's `ToUnicode` entry.
+/// * `font_key` - The font key, used to provide context in errors.
 ///
 /// # Returns
 ///
-/// If the specified font is a CID-keyed font, returns `FontEncoding::CIDKeyed` with a
-/// reference to the `ToUnicode` CMap. Otherwise, returns `FontEncoding::Simple`.
+/// The parsed character-code mappings and the code mapped to U+0020, if present.
+///
+/// # Errors
+///
+/// * `PdfError::EncodingError` if the CMap cannot be read, decompressed, or parsed.
+/// * `PdfError::InternalError` if the CMap reference does not point to a valid object.
+/// * `PdfError::InvalidUtf8` if the decompressed CMap is not valid UTF-8.
+fn read_to_unicode_cmap(
+    doc: &Document,
+    to_unicode: &Object,
+    font_key: &str,
+) -> Result<(CMap, Option<i64>), PdfError> {
+    let cmap_ref = to_unicode.as_reference().map_err(|_| {
+        PdfError::EncodingError(format!(
+            "Font {font_key}'s ToUnicode CMap could not be read."
+        ))
+    })?;
+
+    let decompressed = doc
+        .get_object(cmap_ref)
+        .map_err(|_| {
+            PdfError::InternalError(format!(
+                "Font {font_key}'s ToUnicode CMap points to invalid reference.",
+            ))
+        })?
+        .as_stream()
+        .map_err(|_| {
+            PdfError::EncodingError(format!(
+                "Font {font_key}'s ToUnicode CMap could not be read."
+            ))
+        })?
+        .decompressed_content()
+        .map_err(|_| {
+            PdfError::EncodingError(format!(
+                "Font {font_key}'s ToUnicode CMap could not be deflated."
+            ))
+        })?;
+
+    let cmap = String::from_utf8(decompressed).map_err(|_| PdfError::InvalidUtf8)?;
+    parse_cmap(&cmap, font_key)
+}
+
+/// Attempt to get the font encoding for a font key on a specific page.
+///
+/// This function uses the font subtype and encoding to distinguish simple fonts from CID-keyed
+/// fonts. A `ToUnicode` CMap takes priority for Unicode extraction for either kind of font.
+///
+/// # Returns
+///
+/// The font encoding and any available `ToUnicode` mappings.
 ///
 /// # Errors
 ///
@@ -510,8 +566,11 @@ pub(crate) fn compute_font_encoding(
 ) -> Result<FontEncoding, PdfError> {
     // Test 1: if the font has:
     //   /Subtype /Type1
+    //   /Subtype /MMType1
     //   /Subtype /TrueType
-    // then it is likely a "simple" font.
+    //   /Subtype /Type3
+    // then it is a simple font. ISO 32000-1:2008, §9.10.2, "Mapping character codes to Unicode
+    // values", gives a ToUnicode CMap priority over the font's Encoding when both are present.
     let font_subtype = str::from_utf8(
         font_obj
             .get("Subtype")
@@ -529,8 +588,18 @@ pub(crate) fn compute_font_encoding(
         ))
     })?;
 
-    if ["Type1", "TrueType"].contains(&font_subtype) {
-        return Ok(FontEncoding::Simple);
+    if ["Type1", "MMType1", "TrueType", "Type3"].contains(&font_subtype) {
+        let (mappings, space_code) = match font_obj.get("ToUnicode") {
+            Some(to_unicode) => {
+                let (mappings, space_code) = read_to_unicode_cmap(doc, to_unicode, font_key)?;
+                (Some(mappings), space_code)
+            }
+            None => (None, None),
+        };
+        return Ok(FontEncoding::Simple {
+            mappings,
+            space_code,
+        });
     }
 
     // Test 2: if the font has:
@@ -544,7 +613,10 @@ pub(crate) fn compute_font_encoding(
         log::warn!(
             "Could not determine font type for {font_key}, assuming simple. This may be wrong."
         );
-        return Ok(FontEncoding::Simple);
+        return Ok(FontEncoding::Simple {
+            mappings: None,
+            space_code: None,
+        });
     };
     let font_encoding = str::from_utf8(font_encoding.as_name().map_err(|_| {
         PdfError::EncodingError(format!(
@@ -558,7 +630,10 @@ pub(crate) fn compute_font_encoding(
     })?;
 
     if ["WinAnsiEncoding", "MacRomanEncoding"].contains(&font_encoding) {
-        Ok(FontEncoding::Simple)
+        Ok(FontEncoding::Simple {
+            mappings: None,
+            space_code: None,
+        })
     } else if ["Identity-H", "Identity-V"].contains(&font_encoding) || font_encoding == "Type0" {
         // Test 3: if the font has:
         //   /Subtype /Type0
@@ -570,34 +645,7 @@ pub(crate) fn compute_font_encoding(
             return Ok(FontEncoding::Unmappable);
         };
 
-        let cmap_ref = to_unicode.as_reference().map_err(|_| {
-            PdfError::EncodingError(format!(
-                "CID-keyed font {font_key}'s ToUnicode CMap could not be read."
-            ))
-        })?;
-
-        let decompressed = doc
-            .get_object(cmap_ref)
-            .map_err(|_| {
-                PdfError::InternalError(format!(
-                    "Font {font_key}'s ToUnicode CMap points to invalid reference.",
-                ))
-            })?
-            .as_stream()
-            .map_err(|_| {
-                PdfError::EncodingError(format!(
-                    "CID-keyed font {font_key}'s ToUnicode CMap could not be read."
-                ))
-            })?
-            .decompressed_content()
-            .map_err(|_| {
-                PdfError::EncodingError(format!(
-                    "CID-keyed font {font_key}'s ToUnicode CMap could not be deflated."
-                ))
-            })?;
-
-        let cmap = String::from_utf8(decompressed).map_err(|_| PdfError::InvalidUtf8)?;
-        let (mappings, space_cid) = parse_cmap(&cmap, font_key)?;
+        let (mappings, space_cid) = read_to_unicode_cmap(doc, to_unicode, font_key)?;
 
         Ok(FontEncoding::CIDKeyed {
             mappings,
@@ -608,7 +656,10 @@ pub(crate) fn compute_font_encoding(
         log::warn!(
             "No heuristic matched for font {font_key}; assuming simple. This is likely wrong."
         );
-        Ok(FontEncoding::Simple)
+        Ok(FontEncoding::Simple {
+            mappings: None,
+            space_code: None,
+        })
     }
 }
 
@@ -758,14 +809,20 @@ pub(crate) fn get_space_width(
         .unwrap_or(0_i64);
 
     match font_encoding {
-        #[allow(clippy::cast_possible_truncation)]
-        #[allow(clippy::cast_sign_loss)]
-        FontEncoding::Simple => font_dict
-            .get("Widths")
-            .and_then(|w| w.as_array().ok())
-            .and_then(|ws| ws.get((32 - first_char) as usize))
-            .and_then(|w| w.as_float().ok())
-            .unwrap_or(DEFAULT_SPACE_WIDTH),
+        FontEncoding::Simple { space_code, .. } => {
+            let space_code = space_code.unwrap_or(32);
+            font_dict
+                .get("Widths")
+                .and_then(|w| w.as_array().ok())
+                .and_then(|ws| {
+                    space_code
+                        .checked_sub(first_char)
+                        .and_then(|index| usize::try_from(index).ok())
+                        .and_then(|index| ws.get(index))
+                })
+                .and_then(|w| w.as_float().ok())
+                .unwrap_or(DEFAULT_SPACE_WIDTH)
+        }
         FontEncoding::CIDKeyed { space_cid, .. } => {
             // /W and /DW are defined using the CIDFont dictionary (ISO 32000-2:2020 §9.7.4.3);
             // the Type0 parent has no such entries.

--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -50,57 +50,86 @@ pub(crate) struct FontSizeMarker {
 /// A type to convert from bytes in math fonts to LaTeX code
 type ByteTransformFn = fn(u8) -> Option<std::borrow::Cow<'static, str>>;
 
-/// A zero-allocation iterator for octal escape sequences and raw bytes. This is useful for parsing
-/// octal escape codes that are used in math fonts when non-printable characters are used to
-/// represent symbols.
+/// A zero-allocation iterator that decodes PDF literal-string escape sequences into character
+/// codes.
 pub(crate) struct IterCodepoints<'a> {
     bytes: &'a [u8],
     pos: usize,
+}
+
+impl<'a> IterCodepoints<'a> {
+    /// Create an iterator over the decoded character codes in a PDF literal string.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - The bytes between the literal string's parentheses.
+    ///
+    /// # Returns
+    ///
+    /// An iterator that decodes escaped control characters, delimiters, octal codes, and line
+    /// continuations without allocating.
+    pub(crate) const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
 }
 
 impl Iterator for IterCodepoints<'_> {
     type Item = u8;
 
     fn next(&mut self) -> Option<u8> {
-        if self.pos >= self.bytes.len() {
-            return None;
-        }
-        let b = self.bytes[self.pos];
-        if b == b'\\' {
-            // Possible octal escape
-            let rem = self.bytes.len() - self.pos;
-            if rem >= 4  // Length of octal escape sequence
-                && self.bytes[self.pos + 1] == b'0'
-                && self.bytes[self.pos + 2].is_ascii_digit()
-                && self.bytes[self.pos + 2] < b'8'
-                && self.bytes[self.pos + 3].is_ascii_digit()
-                && self.bytes[self.pos + 3] < b'8'
-            {
-                let oct = &self.bytes[self.pos + 1..=self.pos + 3];
-                let code = (oct[1] - b'0') * 8 + (oct[2] - b'0');
-                self.pos += 4;
-                Some(code)
-            } else {
-                // Just a backslash or malformed escape
-                self.pos += 1;
-                Some(b'\\')
-            }
-        } else {
+        loop {
+            let &byte = self.bytes.get(self.pos)?;
             self.pos += 1;
-            Some(b)
+            if byte != b'\\' {
+                return Some(byte);
+            }
+
+            let Some(&escaped) = self.bytes.get(self.pos) else {
+                return Some(b'\\');
+            };
+            self.pos += 1;
+
+            match escaped {
+                b'n' => return Some(b'\n'),
+                b'r' => return Some(b'\r'),
+                b't' => return Some(b'\t'),
+                b'b' => return Some(0x08),
+                b'f' => return Some(0x0c),
+                b'\n' => {}
+                b'\r' => {
+                    if self.bytes.get(self.pos) == Some(&b'\n') {
+                        self.pos += 1;
+                    }
+                }
+                b'0'..=b'7' => {
+                    let mut value = escaped - b'0';
+                    let mut digits = 1;
+                    while digits < 3 {
+                        let Some(&digit @ b'0'..=b'7') = self.bytes.get(self.pos) else {
+                            break;
+                        };
+                        let candidate = u16::from(value) * 8 + u16::from(digit - b'0');
+                        let Ok(candidate) = u8::try_from(candidate) else {
+                            break;
+                        };
+                        value = candidate;
+                        self.pos += 1;
+                        digits += 1;
+                    }
+                    return Some(value);
+                }
+                _ => return Some(escaped),
+            }
         }
     }
 }
 
 pub(crate) fn font_transform(input: &str, transform: ByteTransformFn) -> String {
-    IterCodepoints {
-        bytes: input.as_bytes(),
-        pos: 0,
-    }
-    .map(|code| {
-        transform(code).unwrap_or_else(|| std::borrow::Cow::Owned(char::from(code).to_string()))
-    })
-    .collect::<String>()
+    IterCodepoints::new(input.as_bytes())
+        .map(|code| {
+            transform(code).unwrap_or_else(|| std::borrow::Cow::Owned(char::from(code).to_string()))
+        })
+        .collect::<String>()
 }
 
 /// A lazy-loaded hashmap storing conversions from math fonts to LaTeX code
@@ -590,10 +619,15 @@ pub(crate) fn compute_font_encoding(
 
     if ["Type1", "MMType1", "TrueType", "Type3"].contains(&font_subtype) {
         let (mappings, space_code) = match font_obj.get("ToUnicode") {
-            Some(to_unicode) => {
-                let (mappings, space_code) = read_to_unicode_cmap(doc, to_unicode, font_key)?;
-                (Some(mappings), space_code)
-            }
+            Some(to_unicode) => match read_to_unicode_cmap(doc, to_unicode, font_key) {
+                Ok((mappings, space_code)) => (Some(mappings), space_code),
+                Err(error) => {
+                    log::warn!(
+                        "Ignoring unusable ToUnicode CMap for simple font {font_key}: {error}"
+                    );
+                    (None, None)
+                }
+            },
             None => (None, None),
         };
         return Ok(FontEncoding::Simple {
@@ -863,6 +897,20 @@ pub(crate) fn get_space_width(
 mod tests {
     use super::*;
     use zqa_macros::test_eq;
+
+    #[test]
+    fn test_iter_codepoints_decodes_pdf_literal_escapes() {
+        let input = b"\\(A\\)\\\\\\n\\r\\t\\b\\f\\101\\12\\1x\\\r\nB";
+        let decoded: Vec<u8> = IterCodepoints::new(input).collect();
+
+        assert_eq!(
+            decoded,
+            vec![
+                b'(', b'A', b')', b'\\', b'\n', b'\r', b'\t', 0x08, 0x0c, b'A', b'\n', 1, b'x',
+                b'B'
+            ]
+        );
+    }
 
     #[test]
     fn test_parse_cmap_ranged() {

--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -108,11 +108,9 @@ impl Iterator for IterCodepoints<'_> {
                         let Some(&digit @ b'0'..=b'7') = self.bytes.get(self.pos) else {
                             break;
                         };
-                        let candidate = u16::from(value) * 8 + u16::from(digit - b'0');
-                        let Ok(candidate) = u8::try_from(candidate) else {
-                            break;
-                        };
-                        value = candidate;
+                        // ISO 32000-1:2008, §7.3.4.2, "Literal strings", specifies that
+                        // high-order overflow in three-digit octal escapes is ignored.
+                        value = value.wrapping_mul(8).wrapping_add(digit - b'0');
                         self.pos += 1;
                         digits += 1;
                     }
@@ -900,14 +898,14 @@ mod tests {
 
     #[test]
     fn test_iter_codepoints_decodes_pdf_literal_escapes() {
-        let input = b"\\(A\\)\\\\\\n\\r\\t\\b\\f\\101\\12\\1x\\\r\nB";
+        let input = b"\\(A\\)\\\\\\n\\r\\t\\b\\f\\101\\12\\1x\\400\\777\\\r\nB";
         let decoded: Vec<u8> = IterCodepoints::new(input).collect();
 
         assert_eq!(
             decoded,
             vec![
-                b'(', b'A', b')', b'\\', b'\n', b'\r', b'\t', 0x08, 0x0c, b'A', b'\n', 1, b'x',
-                b'B'
+                b'(', b'A', b')', b'\\', b'\n', b'\r', b'\t', 0x08, 0x0c, b'A', b'\n', 1, b'x', 0,
+                255, b'B'
             ]
         );
     }

--- a/zqa-pdftools/src/fonts.rs
+++ b/zqa-pdftools/src/fonts.rs
@@ -122,14 +122,6 @@ impl Iterator for IterCodepoints<'_> {
     }
 }
 
-pub(crate) fn font_transform(input: &str, transform: ByteTransformFn) -> String {
-    IterCodepoints::new(input.as_bytes())
-        .map(|code| {
-            transform(code).unwrap_or_else(|| std::borrow::Cow::Owned(char::from(code).to_string()))
-        })
-        .collect::<String>()
-}
-
 /// A lazy-loaded hashmap storing conversions from math fonts to LaTeX code
 /// Handles most common math fonts, but does not yet support specialized math fonts.
 pub(crate) static FONT_TRANSFORMS: LazyLock<HashMap<&'static str, ByteTransformFn>> =

--- a/zqa-pdftools/src/math/cmex.rs
+++ b/zqa-pdftools/src/math/cmex.rs
@@ -1,9 +1,47 @@
 use std::borrow::Cow;
 
+/// Map common Computer Modern Math Extension character codes to LaTeX.
+///
+/// Only complete operators are mapped. Extensible delimiter fragments are deliberately omitted
+/// because they do not represent standalone characters.
+///
+/// # Arguments
+///
+/// * `ch` - A one-byte character code in the CMEX font encoding.
+///
+/// # Returns
+///
+/// The corresponding LaTeX command, or `None` for delimiters and assembly fragments.
 pub(crate) fn from_cmex(ch: u8) -> Option<Cow<'static, str>> {
     match ch {
-        b'X' => Some(Cow::Borrowed("\\sum")),
-        b'Z' => Some(Cow::Borrowed("\\int")),
+        70 | 71 => Some(Cow::Borrowed("\\bigsqcup")),
+        72 | 73 => Some(Cow::Borrowed("\\oint")),
+        74 | 75 => Some(Cow::Borrowed("\\bigodot")),
+        76 | 77 => Some(Cow::Borrowed("\\bigoplus")),
+        78 | 79 => Some(Cow::Borrowed("\\bigotimes")),
+        80 | 88 => Some(Cow::Borrowed("\\sum")),
+        81 | 89 => Some(Cow::Borrowed("\\prod")),
+        82 | 90 => Some(Cow::Borrowed("\\int")),
+        83 | 91 => Some(Cow::Borrowed("\\bigcup")),
+        84 | 92 => Some(Cow::Borrowed("\\bigcap")),
+        85 | 93 => Some(Cow::Borrowed("\\biguplus")),
+        86 | 94 => Some(Cow::Borrowed("\\bigwedge")),
+        87 | 95 => Some(Cow::Borrowed("\\bigvee")),
+        96 | 97 => Some(Cow::Borrowed("\\coprod")),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_common_cmex_operators() {
+        assert_eq!(from_cmex(72).as_deref(), Some("\\oint"));
+        assert_eq!(from_cmex(80).as_deref(), Some("\\sum"));
+        assert_eq!(from_cmex(89).as_deref(), Some("\\prod"));
+        assert_eq!(from_cmex(95).as_deref(), Some("\\bigvee"));
+        assert_eq!(from_cmex(48), None);
     }
 }

--- a/zqa-pdftools/src/math/cmex.rs
+++ b/zqa-pdftools/src/math/cmex.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-pub(crate) fn from_cmex(ch: u8) -> Cow<'static, str> {
+pub(crate) fn from_cmex(ch: u8) -> Option<Cow<'static, str>> {
     match ch {
-        b'X' => Cow::Borrowed("\\sum"),
-        b'Z' => Cow::Borrowed("\\int"),
-        _ => Cow::Owned(char::from(ch).to_string()),
+        b'X' => Some(Cow::Borrowed("\\sum")),
+        b'Z' => Some(Cow::Borrowed("\\int")),
+        _ => None,
     }
 }

--- a/zqa-pdftools/src/math/cmmi.rs
+++ b/zqa-pdftools/src/math/cmmi.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-pub(crate) fn from_cmmi(ch: u8) -> Cow<'static, str> {
+pub(crate) fn from_cmmi(ch: u8) -> Option<Cow<'static, str>> {
     match ch {
-        b'@' => Cow::Borrowed("\\partial"),
-        18 => Cow::Borrowed("\\theta"), // \022 (non-printable)
-        _ => Cow::Owned(char::from(ch).to_string()),
+        b'@' => Some(Cow::Borrowed("\\partial")),
+        18 => Some(Cow::Borrowed("\\theta")), // \022 (non-printable)
+        _ => None,
     }
 }

--- a/zqa-pdftools/src/math/cmmi.rs
+++ b/zqa-pdftools/src/math/cmmi.rs
@@ -1,9 +1,80 @@
 use std::borrow::Cow;
 
+/// Map common Computer Modern Math Italic character codes to LaTeX.
+///
+/// # Arguments
+///
+/// * `ch` - A one-byte character code in the CMMI font encoding.
+///
+/// # Returns
+///
+/// The corresponding LaTeX command, or `None` when the character can be emitted as-is.
 pub(crate) fn from_cmmi(ch: u8) -> Option<Cow<'static, str>> {
     match ch {
+        0 => Some(Cow::Borrowed("\\Gamma")),
+        1 => Some(Cow::Borrowed("\\Delta")),
+        2 => Some(Cow::Borrowed("\\Theta")),
+        3 => Some(Cow::Borrowed("\\Lambda")),
+        4 => Some(Cow::Borrowed("\\Xi")),
+        5 => Some(Cow::Borrowed("\\Pi")),
+        6 => Some(Cow::Borrowed("\\Sigma")),
+        7 => Some(Cow::Borrowed("\\Upsilon")),
+        8 => Some(Cow::Borrowed("\\Phi")),
+        9 => Some(Cow::Borrowed("\\Psi")),
+        10 => Some(Cow::Borrowed("\\Omega")),
+        11 => Some(Cow::Borrowed("\\alpha")),
+        12 => Some(Cow::Borrowed("\\beta")),
+        13 => Some(Cow::Borrowed("\\gamma")),
+        14 => Some(Cow::Borrowed("\\delta")),
+        15 => Some(Cow::Borrowed("\\varepsilon")),
+        16 => Some(Cow::Borrowed("\\zeta")),
+        17 => Some(Cow::Borrowed("\\eta")),
+        18 => Some(Cow::Borrowed("\\theta")),
+        19 => Some(Cow::Borrowed("\\iota")),
+        20 => Some(Cow::Borrowed("\\kappa")),
+        21 => Some(Cow::Borrowed("\\lambda")),
+        22 => Some(Cow::Borrowed("\\mu")),
+        23 => Some(Cow::Borrowed("\\nu")),
+        24 => Some(Cow::Borrowed("\\xi")),
+        25 => Some(Cow::Borrowed("\\pi")),
+        26 => Some(Cow::Borrowed("\\rho")),
+        27 => Some(Cow::Borrowed("\\sigma")),
+        28 => Some(Cow::Borrowed("\\tau")),
+        29 => Some(Cow::Borrowed("\\upsilon")),
+        30 => Some(Cow::Borrowed("\\phi")),
+        31 => Some(Cow::Borrowed("\\chi")),
+        32 => Some(Cow::Borrowed("\\psi")),
+        33 => Some(Cow::Borrowed("\\omega")),
+        34 => Some(Cow::Borrowed("\\epsilon")),
+        35 => Some(Cow::Borrowed("\\vartheta")),
+        36 => Some(Cow::Borrowed("\\varpi")),
+        37 => Some(Cow::Borrowed("\\varrho")),
+        38 => Some(Cow::Borrowed("\\varsigma")),
+        39 => Some(Cow::Borrowed("\\varphi")),
+        46 => Some(Cow::Borrowed("\\triangleright")),
+        47 => Some(Cow::Borrowed("\\triangleleft")),
         b'@' => Some(Cow::Borrowed("\\partial")),
-        18 => Some(Cow::Borrowed("\\theta")), // \022 (non-printable)
+        b'[' => Some(Cow::Borrowed("\\flat")),
+        b'\\' => Some(Cow::Borrowed("\\natural")),
+        b']' => Some(Cow::Borrowed("\\sharp")),
+        b'`' => Some(Cow::Borrowed("\\ell")),
+        b'{' => Some(Cow::Borrowed("\\imath")),
+        b'|' => Some(Cow::Borrowed("\\jmath")),
+        b'}' => Some(Cow::Borrowed("\\wp")),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_common_cmmi_symbols() {
+        assert_eq!(from_cmmi(11).as_deref(), Some("\\alpha"));
+        assert_eq!(from_cmmi(35).as_deref(), Some("\\vartheta"));
+        assert_eq!(from_cmmi(b'@').as_deref(), Some("\\partial"));
+        assert_eq!(from_cmmi(b'}').as_deref(), Some("\\wp"));
+        assert_eq!(from_cmmi(b'A'), None);
     }
 }

--- a/zqa-pdftools/src/math/cmsy.rs
+++ b/zqa-pdftools/src/math/cmsy.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-pub(crate) fn from_cmsy(ch: u8) -> Cow<'static, str> {
+pub(crate) fn from_cmsy(ch: u8) -> Option<Cow<'static, str>> {
     match ch {
-        10 => Cow::Borrowed("\\otimes"), // \\012 (newline/LF)
-        b'1' => Cow::Borrowed("\\infty"),
-        _ => Cow::Owned(char::from(ch).to_string()),
+        10 => Some(Cow::Borrowed("\\otimes")), // \\012 (newline/LF)
+        b'1' => Some(Cow::Borrowed("\\infty")),
+        _ => None,
     }
 }

--- a/zqa-pdftools/src/math/cmsy.rs
+++ b/zqa-pdftools/src/math/cmsy.rs
@@ -1,9 +1,146 @@
 use std::borrow::Cow;
 
+/// Map common Computer Modern Math Symbols character codes to LaTeX.
+///
+/// # Arguments
+///
+/// * `ch` - A one-byte character code in the CMSY font encoding.
+///
+/// # Returns
+///
+/// The corresponding LaTeX command, or `None` for unsupported character codes.
 pub(crate) fn from_cmsy(ch: u8) -> Option<Cow<'static, str>> {
+    if ch <= 64 {
+        from_cmsy_low(ch)
+    } else {
+        from_cmsy_high(ch)
+    }
+}
+
+/// Map the lower half of the CMSY encoding.
+fn from_cmsy_low(ch: u8) -> Option<Cow<'static, str>> {
     match ch {
-        10 => Some(Cow::Borrowed("\\otimes")), // \\012 (newline/LF)
-        b'1' => Some(Cow::Borrowed("\\infty")),
+        0 => Some(Cow::Borrowed("-")),
+        1 => Some(Cow::Borrowed("\\cdot")),
+        2 => Some(Cow::Borrowed("\\times")),
+        3 => Some(Cow::Borrowed("\\ast")),
+        4 => Some(Cow::Borrowed("\\div")),
+        5 => Some(Cow::Borrowed("\\diamond")),
+        6 => Some(Cow::Borrowed("\\pm")),
+        7 => Some(Cow::Borrowed("\\mp")),
+        8 => Some(Cow::Borrowed("\\oplus")),
+        9 => Some(Cow::Borrowed("\\ominus")),
+        10 => Some(Cow::Borrowed("\\otimes")),
+        11 => Some(Cow::Borrowed("\\oslash")),
+        12 => Some(Cow::Borrowed("\\odot")),
+        14 => Some(Cow::Borrowed("\\circ")),
+        15 => Some(Cow::Borrowed("\\bullet")),
+        16 => Some(Cow::Borrowed("\\asymp")),
+        17 => Some(Cow::Borrowed("\\equiv")),
+        18 => Some(Cow::Borrowed("\\subseteq")),
+        19 => Some(Cow::Borrowed("\\supseteq")),
+        20 => Some(Cow::Borrowed("\\leq")),
+        21 => Some(Cow::Borrowed("\\geq")),
+        22 => Some(Cow::Borrowed("\\preceq")),
+        23 => Some(Cow::Borrowed("\\succeq")),
+        24 => Some(Cow::Borrowed("\\sim")),
+        25 => Some(Cow::Borrowed("\\approx")),
+        26 => Some(Cow::Borrowed("\\subset")),
+        27 => Some(Cow::Borrowed("\\supset")),
+        28 => Some(Cow::Borrowed("\\ll")),
+        29 => Some(Cow::Borrowed("\\gg")),
+        30 => Some(Cow::Borrowed("\\prec")),
+        31 => Some(Cow::Borrowed("\\succ")),
+        32 => Some(Cow::Borrowed("\\leftarrow")),
+        33 => Some(Cow::Borrowed("\\rightarrow")),
+        34 => Some(Cow::Borrowed("\\uparrow")),
+        35 => Some(Cow::Borrowed("\\downarrow")),
+        36 => Some(Cow::Borrowed("\\leftrightarrow")),
+        37 => Some(Cow::Borrowed("\\nearrow")),
+        38 => Some(Cow::Borrowed("\\searrow")),
+        39 => Some(Cow::Borrowed("\\simeq")),
+        40 => Some(Cow::Borrowed("\\Leftarrow")),
+        41 => Some(Cow::Borrowed("\\Rightarrow")),
+        42 => Some(Cow::Borrowed("\\Uparrow")),
+        43 => Some(Cow::Borrowed("\\Downarrow")),
+        44 => Some(Cow::Borrowed("\\Leftrightarrow")),
+        45 => Some(Cow::Borrowed("\\nwarrow")),
+        46 => Some(Cow::Borrowed("\\swarrow")),
+        47 => Some(Cow::Borrowed("\\propto")),
+        48 => Some(Cow::Borrowed("\\prime")),
+        49 => Some(Cow::Borrowed("\\infty")),
+        50 => Some(Cow::Borrowed("\\in")),
+        51 => Some(Cow::Borrowed("\\ni")),
+        52 => Some(Cow::Borrowed("\\triangle")),
+        53 => Some(Cow::Borrowed("\\triangledown")),
+        55 => Some(Cow::Borrowed("\\mapsto")),
+        56 => Some(Cow::Borrowed("\\forall")),
+        57 => Some(Cow::Borrowed("\\exists")),
+        58 => Some(Cow::Borrowed("\\neg")),
+        59 => Some(Cow::Borrowed("\\emptyset")),
+        60 => Some(Cow::Borrowed("\\Re")),
+        61 => Some(Cow::Borrowed("\\Im")),
+        62 => Some(Cow::Borrowed("\\top")),
+        63 => Some(Cow::Borrowed("\\perp")),
+        64 => Some(Cow::Borrowed("\\aleph")),
         _ => None,
+    }
+}
+
+/// Map the upper half of the CMSY encoding.
+fn from_cmsy_high(ch: u8) -> Option<Cow<'static, str>> {
+    match ch {
+        b'A'..=b'Z' => Some(Cow::Owned(format!("\\mathcal{{{}}}", char::from(ch)))),
+        91 => Some(Cow::Borrowed("\\cup")),
+        92 => Some(Cow::Borrowed("\\cap")),
+        93 => Some(Cow::Borrowed("\\uplus")),
+        94 => Some(Cow::Borrowed("\\wedge")),
+        95 => Some(Cow::Borrowed("\\vee")),
+        98 => Some(Cow::Borrowed("\\lfloor")),
+        99 => Some(Cow::Borrowed("\\rfloor")),
+        100 => Some(Cow::Borrowed("\\lceil")),
+        101 => Some(Cow::Borrowed("\\rceil")),
+        102 => Some(Cow::Borrowed("\\{")),
+        103 => Some(Cow::Borrowed("\\}")),
+        104 => Some(Cow::Borrowed("\\langle")),
+        105 => Some(Cow::Borrowed("\\rangle")),
+        106 => Some(Cow::Borrowed("|")),
+        107 => Some(Cow::Borrowed("\\|")),
+        108 => Some(Cow::Borrowed("\\updownarrow")),
+        109 => Some(Cow::Borrowed("\\Updownarrow")),
+        110 => Some(Cow::Borrowed("\\backslash")),
+        111 => Some(Cow::Borrowed("\\wr")),
+        112 => Some(Cow::Borrowed("\\sqrt")),
+        113 => Some(Cow::Borrowed("\\coprod")),
+        114 => Some(Cow::Borrowed("\\nabla")),
+        115 => Some(Cow::Borrowed("\\int")),
+        116 => Some(Cow::Borrowed("\\sqcup")),
+        117 => Some(Cow::Borrowed("\\sqcap")),
+        118 => Some(Cow::Borrowed("\\sqsubseteq")),
+        119 => Some(Cow::Borrowed("\\sqsupseteq")),
+        120 => Some(Cow::Borrowed("\\S")),
+        121 => Some(Cow::Borrowed("\\dagger")),
+        122 => Some(Cow::Borrowed("\\ddagger")),
+        123 => Some(Cow::Borrowed("\\P")),
+        124 => Some(Cow::Borrowed("\\clubsuit")),
+        125 => Some(Cow::Borrowed("\\diamondsuit")),
+        126 => Some(Cow::Borrowed("\\heartsuit")),
+        127 => Some(Cow::Borrowed("\\spadesuit")),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_common_cmsy_symbols() {
+        assert_eq!(from_cmsy(10).as_deref(), Some("\\otimes"));
+        assert_eq!(from_cmsy(32).as_deref(), Some("\\leftarrow"));
+        assert_eq!(from_cmsy(50).as_deref(), Some("\\in"));
+        assert_eq!(from_cmsy(b'F').as_deref(), Some("\\mathcal{F}"));
+        assert_eq!(from_cmsy(114).as_deref(), Some("\\nabla"));
+        assert_eq!(from_cmsy(13), None);
     }
 }

--- a/zqa-pdftools/src/math/msbm.rs
+++ b/zqa-pdftools/src/math/msbm.rs
@@ -1,8 +1,65 @@
 use std::borrow::Cow;
 
+/// Map common AMS Blackboard Bold character codes to LaTeX.
+///
+/// # Arguments
+///
+/// * `ch` - A one-byte character code in the MSBM font encoding.
+///
+/// # Returns
+///
+/// The corresponding LaTeX command, or `None` for unsupported character codes.
 pub(crate) fn from_msbm(ch: u8) -> Option<Cow<'static, str>> {
     match ch {
-        b'A'..=b'Z' | b'a'..=b'z' => Some(Cow::Owned(format!("\\mathbb{{{}}}", char::from(ch)))),
+        0 => Some(Cow::Borrowed("\\lneq")),
+        1 => Some(Cow::Borrowed("\\gneq")),
+        2 => Some(Cow::Borrowed("\\nleq")),
+        3 => Some(Cow::Borrowed("\\ngeq")),
+        4 => Some(Cow::Borrowed("\\nless")),
+        5 => Some(Cow::Borrowed("\\ngtr")),
+        6 => Some(Cow::Borrowed("\\nprec")),
+        7 => Some(Cow::Borrowed("\\nsucc")),
+        12 => Some(Cow::Borrowed("\\lneqq")),
+        13 => Some(Cow::Borrowed("\\gneqq")),
+        14 => Some(Cow::Borrowed("\\npreceq")),
+        15 => Some(Cow::Borrowed("\\nsucceq")),
+        28 => Some(Cow::Borrowed("\\nsim")),
+        29 => Some(Cow::Borrowed("\\ncong")),
+        32 => Some(Cow::Borrowed("\\nsubseteq")),
+        33 => Some(Cow::Borrowed("\\nsupseteq")),
+        44 => Some(Cow::Borrowed("\\nparallel")),
+        63 => Some(Cow::Borrowed("\\varnothing")),
+        64 => Some(Cow::Borrowed("\\nexists")),
+        b'A'..=b'Z' => Some(Cow::Owned(format!("\\mathbb{{{}}}", char::from(ch)))),
+        96 => Some(Cow::Borrowed("\\Finv")),
+        97 => Some(Cow::Borrowed("\\Game")),
+        102 => Some(Cow::Borrowed("\\mho")),
+        103 => Some(Cow::Borrowed("\\eth")),
+        105 => Some(Cow::Borrowed("\\beth")),
+        106 => Some(Cow::Borrowed("\\gimel")),
+        107 => Some(Cow::Borrowed("\\daleth")),
+        108 => Some(Cow::Borrowed("\\lessdot")),
+        109 => Some(Cow::Borrowed("\\gtrdot")),
+        112 => Some(Cow::Borrowed("\\shortmid")),
+        113 => Some(Cow::Borrowed("\\shortparallel")),
+        122 => Some(Cow::Borrowed("\\digamma")),
+        123 => Some(Cow::Borrowed("\\varkappa")),
+        125 | 126 => Some(Cow::Borrowed("\\hbar")),
+        127 => Some(Cow::Borrowed("\\backepsilon")),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_common_msbm_symbols() {
+        assert_eq!(from_msbm(2).as_deref(), Some("\\nleq"));
+        assert_eq!(from_msbm(44).as_deref(), Some("\\nparallel"));
+        assert_eq!(from_msbm(b'R').as_deref(), Some("\\mathbb{R}"));
+        assert_eq!(from_msbm(105).as_deref(), Some("\\beth"));
+        assert_eq!(from_msbm(b'b'), None);
     }
 }

--- a/zqa-pdftools/src/math/msbm.rs
+++ b/zqa-pdftools/src/math/msbm.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
-pub(crate) fn from_msbm(ch: u8) -> Cow<'static, str> {
+pub(crate) fn from_msbm(ch: u8) -> Option<Cow<'static, str>> {
     match ch {
-        b'A'..=b'Z' | b'a'..=b'z' => Cow::Owned(format!("\\mathbb{{{}}}", char::from(ch))),
-        _ => Cow::Owned(char::from(ch).to_string()),
+        b'A'..=b'Z' | b'a'..=b'z' => Some(Cow::Owned(format!("\\mathbb{{{}}}", char::from(ch)))),
+        _ => None,
     }
 }

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -303,7 +303,12 @@ fn append_simple_fallback(result: &mut String, text: &[u8], font_name: &str) {
     if let Some(transform) = FONT_TRANSFORMS.get(font_name) {
         result.push_str(&font_transform(text, *transform));
     } else {
-        result.push_str(text);
+        let decoded = text
+            .as_bytes()
+            .contains(&b'\\')
+            .then(|| IterCodepoints::new(text.as_bytes()).collect::<Vec<_>>());
+        let bytes = decoded.as_deref().unwrap_or(text.as_bytes());
+        result.push_str(std::str::from_utf8(bytes).unwrap_or(""));
     }
 }
 
@@ -1763,6 +1768,23 @@ mod tests {
         assert!(
             result.content.contains("Hello World"),
             "Expected extracted text to contain 'Hello World', got {:?}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn test_simple_font_fallback_decodes_literal_escapes() {
+        let content = b"BT /F1 12 Tf (\\(A\\)\\\\\\102) Tj ET";
+        let (doc, page_id) = doc_with_simple_type1_font(content);
+
+        let mut parser = PdfParser::default();
+        let result = parser
+            .parse_content(&doc, page_id, 0, false)
+            .expect("Simple-font fallback should decode literal escapes");
+
+        assert!(
+            result.content.contains("(A)\\B"),
+            "Expected decoded fallback literal, got {:?}",
             result.content
         );
     }

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -17,7 +17,7 @@ use ordered_float::OrderedFloat;
 
 use crate::edits::{Edit, EditType, apply_edits};
 use crate::fonts::{
-    DEFAULT_SPACE_WIDTH, FONT_TRANSFORMS, FontEncoding, FontSizeMarker, SPACE_WIDTH_FRACTION,
+    CMap, DEFAULT_SPACE_WIDTH, FONT_TRANSFORMS, FontEncoding, FontSizeMarker, SPACE_WIDTH_FRACTION,
     compute_font_encoding, font_transform, get_font, get_space_width,
 };
 use crate::tokenizer::{Token, tokenize};
@@ -274,6 +274,92 @@ struct ParseResult {
     skipped_chars: usize,
 }
 
+/// Look up a one-byte character code in a simple font's `ToUnicode` CMap without allocating a key.
+fn simple_cmap_mapping(mappings: &CMap, code: u8) -> Option<&str> {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let key = [HEX[usize::from(code >> 4)], HEX[usize::from(code & 0x0f)]];
+    let key = std::str::from_utf8(&key).expect("hexadecimal digits are always valid UTF-8");
+    mappings.get(key).map(String::as_str)
+}
+
+/// Append unmapped simple-font bytes as UTF-8, applying a configured math-font transformation.
+///
+/// A simple font may have no `ToUnicode` CMap or one that does not cover every character code.
+/// This fallback preserves direct text extraction and math-to-LaTeX normalization for those
+/// unmapped codes.
+fn append_simple_fallback(result: &mut String, text: &[u8], font_name: &str) {
+    let text = std::str::from_utf8(text).unwrap_or("");
+    if let Some(transform) = FONT_TRANSFORMS.get(font_name) {
+        result.push_str(&font_transform(text, *transform));
+    } else {
+        result.push_str(text);
+    }
+}
+
+/// Append one simple-font character code using the available decoding methods in priority order.
+///
+/// Explicit math-to-LaTeX mappings take priority over `ToUnicode` so mathematical output retains
+/// its normalized representation. Codes without either mapping use [`append_simple_fallback`].
+///
+/// # Arguments
+///
+/// * `result` - The extracted text buffer to append the decoded character to.
+/// * `code` - The one-byte character code to decode.
+/// * `mappings` - The font's parsed `ToUnicode` mappings, if it has a usable CMap.
+/// * `font_name` - The font's base name, used to select any configured math-font transformation.
+fn append_simple_code(result: &mut String, code: u8, mappings: Option<&CMap>, font_name: &str) {
+    if let Some(transform) = FONT_TRANSFORMS.get(font_name)
+        && let Some(transformed) = transform(code)
+    {
+        // known math symbol
+        result.push_str(&transformed);
+    } else if let Some(unicode) = mappings.and_then(|map| simple_cmap_mapping(map, code)) {
+        // `ToUnicode` mapping available
+        result.push_str(unicode);
+    } else {
+        // push the raw byte as-is
+        append_simple_fallback(result, std::slice::from_ref(&code), font_name);
+    }
+}
+
+/// Decode a hexadecimal string for a simple font, giving `ToUnicode` mappings priority.
+///
+/// Whitespace between hexadecimal digits is ignored. Character codes present in `mappings` are
+/// converted to Unicode, while unmapped codes use the simple-font fallback decoder. As required by
+/// ISO 32000-1:2008, §7.3.4.3, "Hexadecimal strings", an odd final digit is padded with a zero.
+///
+/// # Arguments
+///
+/// * `result` - The extracted text buffer to append decoded text to.
+/// * `hex` - The hexadecimal digits from the PDF string, with optional ASCII whitespace.
+/// * `mappings` - The font's parsed `ToUnicode` mappings, if it has a usable CMap.
+/// * `font_name` - The font's base name, used to select any configured math-font transformation.
+fn append_simple_hex(result: &mut String, hex: &[u8], mappings: Option<&CMap>, font_name: &str) {
+    let mut high_nibble = None;
+    for &digit in hex.iter().filter(|digit| !digit.is_ascii_whitespace()) {
+        let Some(nibble) = char::from(digit)
+            .to_digit(16)
+            .and_then(|value| u8::try_from(value).ok())
+        else {
+            log::warn!("Invalid hexadecimal digit in simple-font text string");
+            return;
+        };
+
+        if let Some(high) = high_nibble.take() {
+            let code = high << 4 | nibble;
+            append_simple_code(result, code, mappings, font_name);
+        } else {
+            high_nibble = Some(nibble);
+        }
+    }
+
+    // The standard pads an odd final hexadecimal digit with a low-order zero.
+    if let Some(high) = high_nibble {
+        let code = high << 4;
+        append_simple_code(result, code, mappings, font_name);
+    }
+}
+
 impl PdfParser {
     /// Creates a new parser with the given configuration
     ///
@@ -292,17 +378,15 @@ impl PdfParser {
         }
     }
 
-    /// Checks if a given font in a specific page of a document is a CID-keyed font.
+    /// Gets the encoding for a font on a specific page.
     ///
-    /// If it is, returns the `ToUnicode` CMap for that font; otherwise, returns
-    /// FontEncoding::Simple. This function is *not* pure: it updates `self.font_type`, which
-    /// acts as a cache for these results. Entries are keyed by `(page_id, font_key)`, so the
-    /// cache does not need to be cleared between pages.
+    /// This function is *not* pure: it updates `self.font_type`, which acts as a cache for these
+    /// results. Entries are keyed by `(page_id, font_key)`, so the cache does not need to be cleared
+    /// between pages.
     ///
     /// # Returns
     ///
-    /// If the specified font is a CID-keyed font, returns `FontEncoding::CIDKeyed` with a
-    /// reference to the `ToUnicode` CMap. Otherwise, returns `FontEncoding::Simple`.
+    /// The font encoding and any available `ToUnicode` mappings.
     ///
     /// # Errors
     ///
@@ -321,7 +405,7 @@ impl PdfParser {
     ///
     /// * If any of the keys in the font dictionary are not valid UTF-8.
     #[allow(clippy::too_many_lines)]
-    fn is_cid_keyed_font(
+    fn font_encoding(
         &mut self,
         doc: &Document,
         page_id: PageID,
@@ -349,7 +433,7 @@ impl PdfParser {
     ///
     /// * `doc` - The PDF document.
     /// * `page_id` - The page the font appears on.
-    /// * `font_encoding` - The font's encoding, e.g. from [`Self::is_cid_keyed_font`].
+    /// * `font_encoding` - The font's encoding, e.g. from [`Self::font_encoding`].
     ///
     /// # Returns
     ///
@@ -539,7 +623,7 @@ impl PdfParser {
 
         let mut i = 0;
         let font_encoding = self
-            .is_cid_keyed_font(doc, page_id, &font_id)
+            .font_encoding(doc, page_id, &font_id)
             .unwrap_or_else(|_| Rc::new(FontEncoding::Unmappable));
 
         while i < tokens.len() {
@@ -547,12 +631,19 @@ impl PdfParser {
                 Token::Literal(text) => {
                     // Simple font encoding - handle math fonts
                     match &*font_encoding {
-                        FontEncoding::Simple => {
-                            let text_str = std::str::from_utf8(text).unwrap_or("");
-                            if let Some(transform) = FONT_TRANSFORMS.get(cur_font.as_str()) {
-                                result += &font_transform(text_str, *transform);
+                        FontEncoding::Simple { mappings, .. } => {
+                            if let Some(mappings) = mappings {
+                                for &code in *text {
+                                    append_simple_code(
+                                        &mut result,
+                                        code,
+                                        Some(mappings),
+                                        cur_font.as_str(),
+                                    );
+                                }
                             } else {
-                                result += text_str;
+                                // Decode the complete string so contiguous UTF-8 remains intact.
+                                append_simple_fallback(&mut result, text, cur_font.as_str());
                             }
                         }
                         FontEncoding::CIDKeyed { .. } => {
@@ -608,8 +699,13 @@ impl PdfParser {
                                 j += 4;
                             }
                         }
-                        FontEncoding::Simple => {
-                            log::warn!("Unexpected Hex token in simple font");
+                        FontEncoding::Simple { mappings, .. } => {
+                            append_simple_hex(
+                                &mut result,
+                                hex_str,
+                                mappings.as_ref(),
+                                cur_font.as_str(),
+                            );
                         }
                         FontEncoding::Unmappable => {
                             // CIDs are two bytes each, encoded as four hex digits; use the
@@ -1536,10 +1632,18 @@ mod tests {
     /// whose resource dictionary has a single font `F1` described by `font_dict_entries`.
     fn doc_with_font(
         content: &[u8],
-        font_dict_entries: Vec<(&'static str, lopdf::Object)>,
+        mut font_dict_entries: Vec<(&'static str, lopdf::Object)>,
+        to_unicode: Option<&[u8]>,
     ) -> (Document, PageID) {
         let mut doc = Document::with_version("1.5");
 
+        if let Some(to_unicode) = to_unicode {
+            let cmap_id = doc.add_object(lopdf::Stream::new(
+                lopdf::Dictionary::new(),
+                to_unicode.to_vec(),
+            ));
+            font_dict_entries.push(("ToUnicode", lopdf::Object::Reference(cmap_id)));
+        }
         let font_id = doc.add_object(lopdf::Dictionary::from_iter(font_dict_entries));
 
         let content_id = doc.add_object(lopdf::Stream::new(
@@ -1592,6 +1696,7 @@ mod tests {
                 ("BaseFont", lopdf::Object::Name(b"FakeFont".to_vec())),
                 ("Encoding", lopdf::Object::Name(b"Identity-H".to_vec())),
             ],
+            None,
         )
     }
 
@@ -1605,6 +1710,26 @@ mod tests {
                 ("Subtype", lopdf::Object::Name(b"Type1".to_vec())),
                 ("BaseFont", lopdf::Object::Name(b"Helvetica".to_vec())),
             ],
+            None,
+        )
+    }
+
+    /// Build a minimal in-memory PDF using a simple Type1 font with a `ToUnicode` CMap.
+    fn doc_with_simple_type1_tounicode_font(content: &[u8]) -> (Document, PageID) {
+        let cmap = b"\
+1 beginbfchar
+<41> <03a9>
+<42> <03b2>
+endbfchar";
+        doc_with_font(
+            content,
+            vec![
+                ("Type", lopdf::Object::Name(b"Font".to_vec())),
+                ("Subtype", lopdf::Object::Name(b"Type1".to_vec())),
+                ("BaseFont", lopdf::Object::Name(b"Helvetica".to_vec())),
+                ("Encoding", lopdf::Object::Name(b"WinAnsiEncoding".to_vec())),
+            ],
+            Some(cmap),
         )
     }
 
@@ -1621,6 +1746,30 @@ mod tests {
         assert!(
             result.content.contains("Hello World"),
             "Expected extracted text to contain 'Hello World', got {:?}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn test_simple_font_tounicode_overrides_encoding() {
+        // A and B would decode literally under WinAnsiEncoding, but ToUnicode has priority for both
+        // literal and hexadecimal PDF string syntax.
+        let content = b"BT /F1 12 Tf (A) Tj <42> Tj ET";
+        let (doc, page_id) = doc_with_simple_type1_tounicode_font(content);
+
+        let mut parser = PdfParser::default();
+        let result = parser
+            .parse_content(&doc, page_id, 0, false)
+            .expect("A simple font's ToUnicode CMap should be used");
+
+        assert!(
+            result.content.contains("Ωβ"),
+            "Expected ToUnicode mappings to override WinAnsiEncoding, got {:?}",
+            result.content
+        );
+        assert!(
+            !result.content.contains('A') && !result.content.contains('B'),
+            "Raw character codes leaked into extracted text: {:?}",
             result.content
         );
     }

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -1260,7 +1260,18 @@ mod tests {
         check_pdf_contains("test1.pdf", &["Oversampling", "GHOST", "Deep Learning"]);
 
         // Test 2: "ntk.pdf"
-        check_pdf_contains("ntk.pdf", &["\\theta", "\\otimes", "\\sum", "\\mathbb{E}"]);
+        check_pdf_contains(
+            "ntk.pdf",
+            &[
+                "\\theta",
+                "\\otimes",
+                "\\sum",
+                "\\mathbb{E}",
+                "\\in",
+                "\\partial",
+                "\\nabla",
+            ],
+        );
 
         // Test 3: "manifold.pdf", contains CID-keyed fonts
         check_pdf_contains("manifold.pdf", &["Manifold", "Dimension"]);

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -18,7 +18,7 @@ use ordered_float::OrderedFloat;
 use crate::edits::{Edit, EditType, apply_edits};
 use crate::fonts::{
     CMap, DEFAULT_SPACE_WIDTH, FONT_TRANSFORMS, FontEncoding, FontSizeMarker, IterCodepoints,
-    SPACE_WIDTH_FRACTION, compute_font_encoding, font_transform, get_font, get_space_width,
+    SPACE_WIDTH_FRACTION, compute_font_encoding, get_font, get_space_width,
 };
 use crate::tokenizer::{Token, tokenize};
 
@@ -293,29 +293,19 @@ fn simple_cmap_mapping(mappings: &CMap, code: u8) -> Option<&str> {
         .map(String::as_str)
 }
 
-/// Append unmapped simple-font bytes as UTF-8, applying a configured math-font transformation.
-///
-/// A simple font may have no `ToUnicode` CMap or one that does not cover every character code.
-/// This fallback preserves direct text extraction and math-to-LaTeX normalization for those
-/// unmapped codes.
-fn append_simple_fallback(result: &mut String, text: &[u8], font_name: &str) {
-    let text = std::str::from_utf8(text).unwrap_or("");
-    if let Some(transform) = FONT_TRANSFORMS.get(font_name) {
-        result.push_str(&font_transform(text, *transform));
-    } else {
-        let decoded = text
-            .as_bytes()
-            .contains(&b'\\')
-            .then(|| IterCodepoints::new(text.as_bytes()).collect::<Vec<_>>());
-        let bytes = decoded.as_deref().unwrap_or(text.as_bytes());
-        result.push_str(std::str::from_utf8(bytes).unwrap_or(""));
-    }
-}
-
 /// Append one simple-font character code using the available decoding methods in priority order.
 ///
 /// Explicit math-to-LaTeX mappings take priority over `ToUnicode` so mathematical output retains
-/// its normalized representation. Codes without either mapping use [`append_simple_fallback`].
+/// its normalized representation. PDF literal and hexadecimal strings contain font character
+/// codes rather than UTF-8, so each code is decoded independently. This prevents one unmapped
+/// high-byte code from suppressing adjacent text. For example, `\377abc` contains the four
+/// character codes `0xff`, `a`, `b`, and `c`; an unmapped `0xff` does not suppress `abc`.
+///
+/// Until simple-font `/Encoding` and `/Differences` entries are supported, a code without a math
+/// transform or `ToUnicode` mapping is preserved by interpreting its numeric byte value as the same
+/// Unicode scalar value.
+///
+/// TODO(ZOT-216): Resolve unmapped codes through the simple font's `/Encoding` and `/Differences`.
 ///
 /// # Arguments
 ///
@@ -333,8 +323,7 @@ fn append_simple_code(result: &mut String, code: u8, mappings: Option<&CMap>, fo
         // `ToUnicode` mapping available
         result.push_str(unicode);
     } else {
-        // push the raw byte as-is
-        append_simple_fallback(result, std::slice::from_ref(&code), font_name);
+        result.push(char::from(code));
     }
 }
 
@@ -648,18 +637,13 @@ impl PdfParser {
                     // Simple font encoding - handle math fonts
                     match &*font_encoding {
                         FontEncoding::Simple { mappings, .. } => {
-                            if let Some(mappings) = mappings {
-                                for code in IterCodepoints::new(text) {
-                                    append_simple_code(
-                                        &mut result,
-                                        code,
-                                        Some(mappings),
-                                        cur_font.as_str(),
-                                    );
-                                }
-                            } else {
-                                // Decode the complete string so contiguous UTF-8 remains intact.
-                                append_simple_fallback(&mut result, text, cur_font.as_str());
+                            for code in IterCodepoints::new(text) {
+                                append_simple_code(
+                                    &mut result,
+                                    code,
+                                    mappings.as_ref(),
+                                    cur_font.as_str(),
+                                );
                             }
                         }
                         FontEncoding::CIDKeyed { .. } => {
@@ -1774,7 +1758,7 @@ mod tests {
 
     #[test]
     fn test_simple_font_fallback_decodes_literal_escapes() {
-        let content = b"BT /F1 12 Tf (\\(A\\)\\\\\\102) Tj ET";
+        let content = b"BT /F1 12 Tf (\\(A\\)\\\\\\102\\377abc) Tj ET";
         let (doc, page_id) = doc_with_simple_type1_font(content);
 
         let mut parser = PdfParser::default();
@@ -1783,8 +1767,47 @@ mod tests {
             .expect("Simple-font fallback should decode literal escapes");
 
         assert!(
-            result.content.contains("(A)\\B"),
+            result.content.contains("(A)\\Bÿabc"),
             "Expected decoded fallback literal, got {:?}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn test_simple_font_fallback_preserves_high_bytes_in_literal_and_hex_strings() {
+        let content = b"BT /F1 12 Tf (\xffabc) Tj <ff616263> Tj ET";
+        let (doc, page_id) = doc_with_simple_type1_font(content);
+
+        let mut parser = PdfParser::default();
+        let result = parser
+            .parse_content(&doc, page_id, 0, false)
+            .expect("High-byte character codes should not suppress adjacent text");
+
+        assert!(
+            result.content.contains("ÿabcÿabc"),
+            "Expected literal and hexadecimal fallbacks to preserve every code, got {:?}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn test_simple_font_partial_tounicode_preserves_unmapped_codes() {
+        let content = b"BT /F1 12 Tf (a\\377b) Tj ET";
+        let cmap = b"\
+2 beginbfchar
+<61> <03b1>
+<62> <03b2>
+endbfchar";
+        let (doc, page_id) = doc_with_simple_type1_tounicode_font(content, cmap);
+
+        let mut parser = PdfParser::default();
+        let result = parser
+            .parse_content(&doc, page_id, 0, false)
+            .expect("An unmapped code should not prevent adjacent ToUnicode mappings");
+
+        assert!(
+            result.content.contains("αÿβ"),
+            "Expected mapped and fallback codes to be preserved independently, got {:?}",
             result.content
         );
     }

--- a/zqa-pdftools/src/parse.rs
+++ b/zqa-pdftools/src/parse.rs
@@ -17,8 +17,8 @@ use ordered_float::OrderedFloat;
 
 use crate::edits::{Edit, EditType, apply_edits};
 use crate::fonts::{
-    CMap, DEFAULT_SPACE_WIDTH, FONT_TRANSFORMS, FontEncoding, FontSizeMarker, SPACE_WIDTH_FRACTION,
-    compute_font_encoding, font_transform, get_font, get_space_width,
+    CMap, DEFAULT_SPACE_WIDTH, FONT_TRANSFORMS, FontEncoding, FontSizeMarker, IterCodepoints,
+    SPACE_WIDTH_FRACTION, compute_font_encoding, font_transform, get_font, get_space_width,
 };
 use crate::tokenizer::{Token, tokenize};
 
@@ -277,9 +277,20 @@ struct ParseResult {
 /// Look up a one-byte character code in a simple font's `ToUnicode` CMap without allocating a key.
 fn simple_cmap_mapping(mappings: &CMap, code: u8) -> Option<&str> {
     const HEX: &[u8; 16] = b"0123456789abcdef";
-    let key = [HEX[usize::from(code >> 4)], HEX[usize::from(code & 0x0f)]];
-    let key = std::str::from_utf8(&key).expect("hexadecimal digits are always valid UTF-8");
-    mappings.get(key).map(String::as_str)
+    let high = HEX[usize::from(code >> 4)];
+    let low = HEX[usize::from(code & 0x0f)];
+    let short_key = [high, low];
+    let short_key =
+        std::str::from_utf8(&short_key).expect("hexadecimal digits are always valid UTF-8");
+    mappings
+        .get(short_key)
+        .or_else(|| {
+            let padded_key = [b'0', b'0', high, low];
+            let padded_key = std::str::from_utf8(&padded_key)
+                .expect("hexadecimal digits are always valid UTF-8");
+            mappings.get(padded_key)
+        })
+        .map(String::as_str)
 }
 
 /// Append unmapped simple-font bytes as UTF-8, applying a configured math-font transformation.
@@ -633,7 +644,7 @@ impl PdfParser {
                     match &*font_encoding {
                         FontEncoding::Simple { mappings, .. } => {
                             if let Some(mappings) = mappings {
-                                for &code in *text {
+                                for code in IterCodepoints::new(text) {
                                     append_simple_code(
                                         &mut result,
                                         code,
@@ -1725,13 +1736,8 @@ mod tests {
         )
     }
 
-    /// Build a minimal in-memory PDF using a simple Type1 font with a `ToUnicode` CMap.
-    fn doc_with_simple_type1_tounicode_font(content: &[u8]) -> (Document, PageID) {
-        let cmap = b"\
-1 beginbfchar
-<41> <03a9>
-<42> <03b2>
-endbfchar";
+    /// Build a minimal in-memory PDF using a simple Type1 font with the provided `ToUnicode` CMap.
+    fn doc_with_simple_type1_tounicode_font(content: &[u8], cmap: &[u8]) -> (Document, PageID) {
         doc_with_font(
             content,
             vec![
@@ -1766,7 +1772,12 @@ endbfchar";
         // A and B would decode literally under WinAnsiEncoding, but ToUnicode has priority for both
         // literal and hexadecimal PDF string syntax.
         let content = b"BT /F1 12 Tf (A) Tj <42> Tj ET";
-        let (doc, page_id) = doc_with_simple_type1_tounicode_font(content);
+        let cmap = b"\
+1 beginbfchar
+<41> <03a9>
+<42> <03b2>
+endbfchar";
+        let (doc, page_id) = doc_with_simple_type1_tounicode_font(content, cmap);
 
         let mut parser = PdfParser::default();
         let result = parser
@@ -1781,6 +1792,73 @@ endbfchar";
         assert!(
             !result.content.contains('A') && !result.content.contains('B'),
             "Raw character codes leaked into extracted text: {:?}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn test_simple_font_tounicode_accepts_padded_source_codes() {
+        let content = b"BT /F1 12 Tf (A) Tj ET";
+        let cmap = b"\
+1 beginbfchar
+<0041> <03a9>
+endbfchar";
+        let (doc, page_id) = doc_with_simple_type1_tounicode_font(content, cmap);
+
+        let mut parser = PdfParser::default();
+        let result = parser
+            .parse_content(&doc, page_id, 0, false)
+            .expect("A padded simple-font source code should be mapped");
+
+        assert!(
+            result.content.contains('Ω'),
+            "Expected padded ToUnicode source code to map, got {:?}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn test_simple_font_tounicode_decodes_literal_escapes() {
+        let content = b"BT /F1 12 Tf (\\101\\(B\\)\\\\) Tj ET";
+        let cmap = b"\
+5 beginbfchar
+<28> <005b>
+<29> <005d>
+<41> <03a9>
+<42> <03b2>
+<5c> <002f>
+endbfchar";
+        let (doc, page_id) = doc_with_simple_type1_tounicode_font(content, cmap);
+
+        let mut parser = PdfParser::default();
+        let result = parser
+            .parse_content(&doc, page_id, 0, false)
+            .expect("Literal escapes should decode before ToUnicode lookup");
+
+        assert!(
+            result.content.contains("Ω[β]/"),
+            "Expected decoded literal character codes, got {:?}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn test_simple_font_with_unusable_tounicode_uses_fallback() {
+        let content = b"BT /F1 12 Tf (Readable) Tj ET";
+        let cmap = b"\
+1 beginbfrange
+<41> <42> [<03a9> <03b2>]
+endbfrange";
+        let (doc, page_id) = doc_with_simple_type1_tounicode_font(content, cmap);
+
+        let mut parser = PdfParser::default();
+        let result = parser
+            .parse_content(&doc, page_id, 0, false)
+            .expect("An unusable optional ToUnicode CMap should not prevent fallback extraction");
+
+        assert!(
+            result.content.contains("Readable"),
+            "Expected simple-font fallback text, got {:?}",
             result.content
         );
     }


### PR DESCRIPTION
## Summary

- honor `ToUnicode` CMaps for Type 1, MMType1, TrueType, and Type 3 simple fonts
- decode both literal and hexadecimal simple-font strings through the same per-code mapping path
- preserve explicit math-to-LaTeX normalization while falling back for incomplete or absent CMaps
- expand common CMMI, CMSY, CMEX, and MSBM symbol mappings for PDFs without usable `ToUnicode` data

## Rationale

The PDF specification gives `ToUnicode` mappings priority for text extraction regardless of whether a font is simple or composite. Previously, simple fonts bypassed these mappings, while embedded Computer Modern and AMS fonts without usable CMaps only recognized a small set of symbols.

## Testing

- `cargo test -p zqa-pdftools` (66 passed, 3 ignored)
- `cargo clippy -p zqa-pdftools --all-targets --all-features -- -D warnings`
- `cargo fmt --all`

Closes: ZOT-120, ZOT-112